### PR TITLE
クイズ回答機能の実装

### DIFF
--- a/backend/app/controllers/api/v1/quiz_answer_records_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_answer_records_controller.rb
@@ -1,0 +1,4 @@
+class Api::V1::QuizAnswerRecordsController < ApplicationController
+  def create
+  end
+end

--- a/backend/app/controllers/api/v1/quiz_answer_records_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_answer_records_controller.rb
@@ -1,4 +1,21 @@
 class Api::V1::QuizAnswerRecordsController < ApplicationController
+  before_action :quiz_answer_record_params, only: [:create]
+
   def create
+    quiz_answer_records = QuizAnswerRecord.new(quiz_answer_record_params)
+    if quiz_answer_records.save!
+      render json: {
+        status: 'SUCCESS',
+        data: quiz_answer_records,
+      }
+    else
+      render json: quiz_answer_records.errors
+    end
+  end
+
+  private
+
+  def quiz_answer_record_params
+    params.require(:quiz_answer_record).permit(:user_id, :quiz_id)
   end
 end

--- a/backend/app/controllers/api/v1/quiz_answer_records_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_answer_records_controller.rb
@@ -3,7 +3,15 @@ class Api::V1::QuizAnswerRecordsController < ApplicationController
 
   def create
     quiz_answer_records = QuizAnswerRecord.new(quiz_answer_record_params)
-    if quiz_answer_records.save!
+    if QuizAnswerRecord.exists?(
+      user_id: quiz_answer_record_params[:user_id],
+      quiz_id: quiz_answer_record_params[:quiz_id],
+    )
+      render json: {
+        status: "SUCCESS",
+        messaeg: "既に解答済みのデータは存在しています。",
+      }
+    elsif quiz_answer_records.save
       render json: {
         status: 'SUCCESS',
         data: quiz_answer_records,

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -4,10 +4,12 @@ class Api::V1::UsersController < ApplicationController
 
   def show
     quizzes = @user.quizzes
+    quiz_answer_records = @user.quiz_answer_records
     render json: {
       status: 'SUCCESS',
       message: 'Loaded quizzes',
       data: quizzes,
+      data_answer_records: quiz_answer_records,
     }
   end
 

--- a/backend/app/models/quiz.rb
+++ b/backend/app/models/quiz.rb
@@ -1,6 +1,7 @@
 class Quiz < ApplicationRecord
   belongs_to :user
   has_many :quiz_first_or_lasts, dependent: :destroy
+  has_many :quiz_answer_records, dependent: :destroy
 
   validates :quiz_title, presence: true
   validates :quiz_introduction, presence: true, length: { in: 30..200 }

--- a/backend/app/models/quiz_answer_record.rb
+++ b/backend/app/models/quiz_answer_record.rb
@@ -1,0 +1,4 @@
+class QuizAnswerRecord < ApplicationRecord
+  belongs_to :user
+  belongs_to :quiz
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ActiveRecord::Base
 
   mount_uploader :image, ImageUploader
   has_many :quizzes, dependent: :destroy
+  has_many :quiz_answer_records, dependent: :destroy
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
       resources :users, only: %i[show update]
       resources :quizzes, only: %i[index create update show destroy]
+      resources :quiz_answer_records, only: %i[create]
       resources :quiz_first_or_lasts, only: %i[create show destroy]
       resources :quiz_branches, only: %i[create show update destroy]
       resources :quiz_remote_branches, only: %i[create show destroy]

--- a/backend/db/migrate/20221102025459_create_quiz_answer_records.rb
+++ b/backend/db/migrate/20221102025459_create_quiz_answer_records.rb
@@ -1,0 +1,10 @@
+class CreateQuizAnswerRecords < ActiveRecord::Migration[6.1]
+  def change
+    create_table :quiz_answer_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :quiz, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_135436) do
+ActiveRecord::Schema.define(version: 2022_11_02_025459) do
+
+  create_table "quiz_answer_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "quiz_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["quiz_id"], name: "index_quiz_answer_records_on_quiz_id"
+    t.index ["user_id"], name: "index_quiz_answer_records_on_user_id"
+  end
 
   create_table "quiz_branches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "quiz_branch_name"
@@ -149,6 +158,8 @@ ActiveRecord::Schema.define(version: 2022_10_24_135436) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "quiz_answer_records", "quizzes"
+  add_foreign_key "quiz_answer_records", "users"
   add_foreign_key "quiz_branches", "quiz_first_or_lasts"
   add_foreign_key "quiz_commit_messages", "quiz_branches"
   add_foreign_key "quiz_first_or_lasts", "quizzes"

--- a/backend/spec/factories/quiz_answer_records.rb
+++ b/backend/spec/factories/quiz_answer_records.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :quiz_answer_record do
-    user { nil }
-    quiz { nil }
+    user { FactoryBot.create(:user) }
+    quiz { FactoryBot.create(:quiz) }
   end
 end

--- a/backend/spec/factories/quiz_answer_records.rb
+++ b/backend/spec/factories/quiz_answer_records.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :quiz_answer_record do
+    user { nil }
+    quiz { nil }
+  end
+end

--- a/backend/spec/models/quiz_answer_record_spec.rb
+++ b/backend/spec/models/quiz_answer_record_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe QuizAnswerRecord, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  pending "quiz_answer_recordモデルには、外部キーの設定のみのためテストを書いていない。"
 end

--- a/backend/spec/models/quiz_answer_record_spec.rb
+++ b/backend/spec/models/quiz_answer_record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe QuizAnswerRecord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/quiz_spec.rb
+++ b/backend/spec/models/quiz_spec.rb
@@ -59,11 +59,18 @@ RSpec.describe Quiz, type: :model do
     context "quizのデータが削除された場合" do
       let(:quiz) { create(:quiz) }
       let!(:quiz_first_or_last) { create(:quiz_first_or_last, quiz: quiz) }
+      let!(:quiz_answer_record) { create(:quiz_answer_record, quiz: quiz) }
 
-      it "quizに紐づいているquiz_first_or_lastのデータも削除されること" do
+      it "quizに紐づいているquiz_first_or_last/quiz_answer_recordのデータも削除されること" do
         expect do
           quiz.destroy
         end.to change(QuizFirstOrLast, :count).by(-1)
+      end
+
+      it "quizに紐づいているquiz_answer_recordのデータも削除されること" do
+        expect do
+          quiz.destroy
+        end.to change(QuizAnswerRecord, :count).by(-1)
       end
     end
   end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -45,11 +45,18 @@ RSpec.describe User, type: :model do
     context "userのデータが削除された場合" do
       let(:user) { create(:user) }
       let!(:quiz) { create(:quiz, user: user) }
+      let!(:quiz_answer_record) { create(:quiz_answer_record, user: user) }
 
       it "userに紐づいているquizのデータも削除されること" do
         expect do
           user.destroy
-        end.to change(Quiz, :count).by(-1)
+        end.to change(Quiz, :count).by(-1).and change(QuizAnswerRecord, :count).by(-1)
+      end
+
+      it "userに紐づいているquiz_answer_recordのデータも削除されること" do
+        expect do
+          user.destroy
+        end.to change(QuizAnswerRecord, :count).by(-1)
       end
     end
   end

--- a/backend/spec/requests/api/v1/quiz_answer_records_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_answer_records_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::QuizAnswerRecords", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/api/v1/quiz_answer_records/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/api/v1/quiz_answer_records/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/backend/spec/requests/api/v1/quiz_answer_records_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_answer_records_spec.rb
@@ -1,18 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::QuizAnswerRecords", type: :request do
+  let!(:user) { create(:user) }
+  let!(:quiz) { create(:quiz) }
+  let!(:quiz2) { create(:quiz) }
+  let!(:quiz_answer_record) { create(:quiz_answer_record, user: user, quiz: quiz2) }
+  let(:param) do
+    {
+      quiz_answer_record: {
+        user_id: user.id,
+        quiz_id: quiz.id,
+      },
+    }
+  end
+  let(:bad_param) do
+    {
+      quiz_answer_record: {
+        user_id: user.id,
+        quiz_id: quiz2.id,
+      },
+    }
+  end
+
   describe "GET /create" do
-    it "returns http success" do
-      get "/api/v1/quiz_answer_records/create"
-      expect(response).to have_http_status(:success)
+    context "同じ値のquiz_answer_recordがDB内に存在しない場合" do
+      it "データ登録が成功すること" do
+        expect do
+          post api_v1_quiz_answer_records_path, params: param
+        end.to change(QuizAnswerRecord, :count).by(+1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["data"]["user_id"]).to eq(user.id)
+        expect(res["data"]["quiz_id"]).to eq(quiz.id)
+      end
+    end
+
+    context "既に同じ値のquiz_answer_recordがDB内に存在する場合" do
+      it "データ登録が失敗すること" do
+        post api_v1_quiz_answer_records_path, params: bad_param
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["messaeg"]).to eq("既に解答済みのデータは存在しています。")
+      end
     end
   end
-
-  describe "GET /show" do
-    it "returns http success" do
-      get "/api/v1/quiz_answer_records/show"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -9,11 +9,16 @@ RSpec.describe "Api::V1::Users", type: :request do
   let!(:user_quiz2) { create(:quiz, user: user) }
   let!(:user2_quiz1) { create(:quiz, user: user2) }
   let!(:user2_quiz2) { create(:quiz, user: user2) }
+  let!(:related_quiz_answer_record) { create(:quiz_answer_record, user: user, quiz: user2_quiz1) }
+  let!(:not_related_quiz_answer_record) { create(:quiz_answer_record) }
 
   describe "GET /api/v1/users#show" do
     context "引数がquizのidの場合" do
-      it "userの関連しているquizデータのみを取得できること" do
+      before do
         get api_v1_user_path(user.id)
+      end
+
+      it "userの関連しているquizデータのみを取得できること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -22,6 +27,15 @@ RSpec.describe "Api::V1::Users", type: :request do
         expect(res["data"][0]["id"]).not_to eq(user2_quiz1.id)
         expect(res["data"][1]["id"]).not_to eq(user2_quiz2.id)
         expect(res["data"].length).to eq 2
+        expect(response).to have_http_status(:success)
+      end
+
+      it "userの関連しているquiz_answer_recordデータのみを取得できること" do
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["message"]).to eq("Loaded quizzes")
+        expect(res["data_answer_records"][0]["id"]).to eq(related_quiz_answer_record.id)
+        expect(res["data_answer_records"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
     end

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -85,6 +85,7 @@ const App: React.FC = () => {
                 <Route path="/quiz/edit/:id" component={CreateQuiz} />
                 <Route path="/quiz/init/edit/:id" component={CreateQuiz} />
                 <Route path="/quiz/init/:id" component={CreateQuiz} />
+                <Route path="/quiz/answer/:id" component={CreateQuiz} />
               </Switch>
             </Private>
           </Switch>

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -544,7 +544,7 @@ const CreateQuiz: React.FC = () => {
     remoteCommitMessageId: ""
   }])
   const [initialBranches, setInitialBranches] = useState([{
-    branchName: "master",
+    branchName: "",
     branchId: ""
     }])
   const [initialRemoteBranches, setInitialRemoteBranches] = useState([{
@@ -552,7 +552,7 @@ const CreateQuiz: React.FC = () => {
     remoteBranchId: ""
     }])
   const [answerBranches, setAnswerBranches] = useState([{
-    branchName: "master"
+    branchName: ""
     }])
   const [answerRemoteBranches, setAnswerRemoteBranches] = useState([{
     remoteBranchName: ""

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -310,6 +310,98 @@ export const QuizContext = createContext({} as {
     remoteCommitMessageId: string
   }[]>>
 
+  answerBranches: {
+    branchName: string
+    branchId: string
+  }[]
+
+  setAnswerBranches: React.Dispatch<React.SetStateAction<{
+    branchName: string
+    branchId: string
+  }[]>>
+
+  answerRemoteBranches: {
+    remoteBranchName: string
+    remoteBranchId: string
+  }[]
+
+  setAnswerRemoteBranches: React.Dispatch<React.SetStateAction<{
+    remoteBranchName: string
+    remoteBranchId: string
+  }[]>>
+
+  answerWorktreeFiles: {
+    fileName: string
+    parentBranch: string
+    textStatus: string
+    parentBranchId: string
+    worktreeFileId: string
+  }[]
+
+  setAnswerWorktreeFiles: React.Dispatch<React.SetStateAction<{
+    fileName: string
+    parentBranch: string
+    textStatus: string
+    parentBranchId: string
+    worktreeFileId: string
+  }[]>>
+
+  answerIndexFiles: {
+    fileName: string
+    parentBranch: string
+    textStatus: string
+    parentBranchId: string
+    indexFileId: string
+  }[]
+
+  setAnswerIndexFiles: React.Dispatch<React.SetStateAction<{
+    fileName: string
+    parentBranch: string
+    textStatus: string
+    parentBranchId: string
+    indexFileId: string
+  }[]>>
+
+  answerRepositoryFiles: {
+    fileName: string
+    textStatus: string
+    parentBranch: string
+    parentCommitMessage: string
+    parentBranchId: string
+    parentCommitMessageId: string
+    repositoryFileId: string
+  }[]
+
+  setAnswerRepositoryFiles:React.Dispatch<React.SetStateAction<{
+    fileName: string
+    textStatus: string
+    parentBranch: string
+    parentCommitMessage: string
+    parentBranchId: string
+    parentCommitMessageId: string
+    repositoryFileId: string
+  }[]>>
+
+  answerRemoteRepositoryFiles: {
+    fileName: string
+    textStatus: string
+    parentRemoteBranch: string
+    parentRemoteCommitMessage: string
+    parentRemoteBranchId: string
+    parentRemoteCommitMessageId: string
+    remoteRepositoryFileId: string
+  }[]
+
+  setAnswerRemoteRepositoryFiles:React.Dispatch<React.SetStateAction<{
+    fileName: string
+    textStatus: string
+    parentRemoteBranch: string
+    parentRemoteCommitMessage: string
+    parentRemoteBranchId: string
+    parentRemoteCommitMessageId: string
+    remoteRepositoryFileId: string
+  }[]>>
+
   initialBranches: {
     branchName: string
     branchId: string
@@ -483,6 +575,46 @@ const CreateQuiz: React.FC = () => {
     remoteBranchName: "",
     remoteBranchId: ""
     }])
+  const [answerBranches, setAnswerBranches] = useState([{
+    branchName: "master",
+    branchId: ""
+    }])
+  const [answerRemoteBranches, setAnswerRemoteBranches] = useState([{
+    remoteBranchName: "",
+    remoteBranchId: ""
+    }])
+  const [answerRemoteRepositoryFiles, setAnswerRemoteRepositoryFiles] = useState([{
+    fileName: "",
+    textStatus: "",
+    parentRemoteBranch: "",
+    parentRemoteCommitMessage: "",
+    parentRemoteBranchId: "",
+    parentRemoteCommitMessageId: "",
+    remoteRepositoryFileId: ""
+  }])
+  const [answerWorktreeFiles, setAnswerWorktreeFiles] = useState([{
+    fileName: "",
+    parentBranch: "",
+    textStatus: "",
+    parentBranchId: "",
+    worktreeFileId: ""
+  }])
+  const [answerIndexFiles, setAnswerIndexFiles] = useState([{
+    fileName: "",
+    parentBranch: "",
+    textStatus: "",
+    parentBranchId: "",
+    indexFileId: ""
+  }])
+  const [answerRepositoryFiles, setAnswerRepositoryFiles] = useState([{
+    fileName: "",
+    textStatus: "",
+    parentBranch: "",
+    parentCommitMessage: "",
+    parentBranchId: "",
+    parentCommitMessageId: "",
+    repositoryFileId: ""
+  }])
   const [commands, setCommands] = useState([{
     text:"play with git-used-to!!",
     addText:""
@@ -780,23 +912,29 @@ const CreateQuiz: React.FC = () => {
         gitInit,setGitInit,
         currentBranch, setCurrentBranch,
         branches, setBranches,
-        initialBranches,setInitialBranches,
         remoteBranches, setRemoteBranches,
-        initialRemoteBranches,setInitialRemoteBranches,
         worktreeFiles, setWorktreeFiles,
-        initialWorktreeFiles, setInitialWorktreeFiles,
         indexFiles, setIndexFiles,
-        initialIndexFiles,setInitialIndexFiles,
         repositoryFiles, setRepositoryFiles,
-        initialRepositoryFiles,setInitialRepositoryFiles,
         remoteRepositoryFiles, setRemoteRepositoryFiles,
-        initialRemoteRepositoryFiles,setInitialRemoteRepositoryFiles,
         fileHistoryForCansellCommits, setFileHistoryForCansellCommits,
-        initialFileHistoryForCansellCommits,setInitialFileHistoryForCansellCommits,
         commitMessages, setCommitMessages,
-        initialCommitMessages,setInitialCommitMessages,
         remoteCommitMessages, setRemoteCommitMessages,
         initialRemoteCommitMessages, setInitialRemoteCommitMessages,
+        initialBranches,setInitialBranches,
+        initialRemoteBranches,setInitialRemoteBranches,
+        initialWorktreeFiles, setInitialWorktreeFiles,
+        initialIndexFiles,setInitialIndexFiles,
+        initialRepositoryFiles,setInitialRepositoryFiles,
+        initialRemoteRepositoryFiles,setInitialRemoteRepositoryFiles,
+        initialFileHistoryForCansellCommits,setInitialFileHistoryForCansellCommits,
+        initialCommitMessages,setInitialCommitMessages,
+        answerBranches, setAnswerBranches,
+        answerRemoteBranches, setAnswerRemoteBranches,
+        answerWorktreeFiles, setAnswerWorktreeFiles,
+        answerIndexFiles, setAnswerIndexFiles,
+        answerRepositoryFiles, setAnswerRepositoryFiles,
+        answerRemoteRepositoryFiles, setAnswerRemoteRepositoryFiles,
         commands, setCommands
         }}>
       <QuizBranchArea />

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -310,98 +310,6 @@ export const QuizContext = createContext({} as {
     remoteCommitMessageId: string
   }[]>>
 
-  answerBranches: {
-    branchName: string
-    branchId: string
-  }[]
-
-  setAnswerBranches: React.Dispatch<React.SetStateAction<{
-    branchName: string
-    branchId: string
-  }[]>>
-
-  answerRemoteBranches: {
-    remoteBranchName: string
-    remoteBranchId: string
-  }[]
-
-  setAnswerRemoteBranches: React.Dispatch<React.SetStateAction<{
-    remoteBranchName: string
-    remoteBranchId: string
-  }[]>>
-
-  answerWorktreeFiles: {
-    fileName: string
-    parentBranch: string
-    textStatus: string
-    parentBranchId: string
-    worktreeFileId: string
-  }[]
-
-  setAnswerWorktreeFiles: React.Dispatch<React.SetStateAction<{
-    fileName: string
-    parentBranch: string
-    textStatus: string
-    parentBranchId: string
-    worktreeFileId: string
-  }[]>>
-
-  answerIndexFiles: {
-    fileName: string
-    parentBranch: string
-    textStatus: string
-    parentBranchId: string
-    indexFileId: string
-  }[]
-
-  setAnswerIndexFiles: React.Dispatch<React.SetStateAction<{
-    fileName: string
-    parentBranch: string
-    textStatus: string
-    parentBranchId: string
-    indexFileId: string
-  }[]>>
-
-  answerRepositoryFiles: {
-    fileName: string
-    textStatus: string
-    parentBranch: string
-    parentCommitMessage: string
-    parentBranchId: string
-    parentCommitMessageId: string
-    repositoryFileId: string
-  }[]
-
-  setAnswerRepositoryFiles:React.Dispatch<React.SetStateAction<{
-    fileName: string
-    textStatus: string
-    parentBranch: string
-    parentCommitMessage: string
-    parentBranchId: string
-    parentCommitMessageId: string
-    repositoryFileId: string
-  }[]>>
-
-  answerRemoteRepositoryFiles: {
-    fileName: string
-    textStatus: string
-    parentRemoteBranch: string
-    parentRemoteCommitMessage: string
-    parentRemoteBranchId: string
-    parentRemoteCommitMessageId: string
-    remoteRepositoryFileId: string
-  }[]
-
-  setAnswerRemoteRepositoryFiles:React.Dispatch<React.SetStateAction<{
-    fileName: string
-    textStatus: string
-    parentRemoteBranch: string
-    parentRemoteCommitMessage: string
-    parentRemoteBranchId: string
-    parentRemoteCommitMessageId: string
-    remoteRepositoryFileId: string
-  }[]>>
-
   initialBranches: {
     branchName: string
     branchId: string
@@ -420,6 +328,74 @@ export const QuizContext = createContext({} as {
   setInitialRemoteBranches: React.Dispatch<React.SetStateAction<{
     remoteBranchName: string
     remoteBranchId: string
+  }[]>>
+
+  answerBranches: {
+    branchName: string
+  }[]
+
+  setAnswerBranches: React.Dispatch<React.SetStateAction<{
+    branchName: string
+  }[]>>
+
+  answerRemoteBranches: {
+    remoteBranchName: string
+  }[]
+
+  setAnswerRemoteBranches: React.Dispatch<React.SetStateAction<{
+    remoteBranchName: string
+  }[]>>
+
+  answerWorktreeFiles: {
+    fileName: string
+    parentBranch: string
+    textStatus: string
+  }[]
+
+  setAnswerWorktreeFiles: React.Dispatch<React.SetStateAction<{
+    fileName: string
+    parentBranch: string
+    textStatus: string
+  }[]>>
+
+  answerIndexFiles: {
+    fileName: string
+    parentBranch: string
+    textStatus: string
+  }[]
+
+  setAnswerIndexFiles: React.Dispatch<React.SetStateAction<{
+    fileName: string
+    parentBranch: string
+    textStatus: string
+  }[]>>
+
+  answerRepositoryFiles: {
+    fileName: string
+    textStatus: string
+    parentBranch: string
+    parentCommitMessage: string
+  }[]
+
+  setAnswerRepositoryFiles:React.Dispatch<React.SetStateAction<{
+    fileName: string
+    textStatus: string
+    parentBranch: string
+    parentCommitMessage: string
+  }[]>>
+
+  answerRemoteRepositoryFiles: {
+    fileName: string
+    textStatus: string
+    parentRemoteBranch: string
+    parentRemoteCommitMessage: string
+  }[]
+
+  setAnswerRemoteRepositoryFiles:React.Dispatch<React.SetStateAction<{
+    fileName: string
+    textStatus: string
+    parentRemoteBranch: string
+    parentRemoteCommitMessage: string
   }[]>>
 
   commands: {
@@ -576,44 +552,32 @@ const CreateQuiz: React.FC = () => {
     remoteBranchId: ""
     }])
   const [answerBranches, setAnswerBranches] = useState([{
-    branchName: "master",
-    branchId: ""
+    branchName: "master"
     }])
   const [answerRemoteBranches, setAnswerRemoteBranches] = useState([{
-    remoteBranchName: "",
-    remoteBranchId: ""
+    remoteBranchName: ""
     }])
   const [answerRemoteRepositoryFiles, setAnswerRemoteRepositoryFiles] = useState([{
     fileName: "",
     textStatus: "",
     parentRemoteBranch: "",
-    parentRemoteCommitMessage: "",
-    parentRemoteBranchId: "",
-    parentRemoteCommitMessageId: "",
-    remoteRepositoryFileId: ""
+    parentRemoteCommitMessage: ""
   }])
   const [answerWorktreeFiles, setAnswerWorktreeFiles] = useState([{
     fileName: "",
     parentBranch: "",
-    textStatus: "",
-    parentBranchId: "",
-    worktreeFileId: ""
+    textStatus: ""
   }])
   const [answerIndexFiles, setAnswerIndexFiles] = useState([{
     fileName: "",
     parentBranch: "",
-    textStatus: "",
-    parentBranchId: "",
-    indexFileId: ""
+    textStatus: ""
   }])
   const [answerRepositoryFiles, setAnswerRepositoryFiles] = useState([{
     fileName: "",
     textStatus: "",
     parentBranch: "",
-    parentCommitMessage: "",
-    parentBranchId: "",
-    parentCommitMessageId: "",
-    repositoryFileId: ""
+    parentCommitMessage: ""
   }])
   const [commands, setCommands] = useState([{
     text:"play with git-used-to!!",

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -15,6 +15,7 @@ import { createQuizRemoteRepositoryFile, deleteQuizRemoteRepositoryFile } from "
 import { createQuizRemoteCommitMessage, deleteQuizRemoteCommitMessage } from "lib/api/quiz_remote_commit_messages";
 import { AuthContext } from "App";
 import { useHistory, useLocation, useParams } from "react-router-dom";
+import { execPath } from "process";
 
 const useStyles = makeStyles((theme: Theme) => ({
   submitBtn: {
@@ -54,6 +55,12 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     initialCommitMessages,
     remoteCommitMessages,
     initialRemoteCommitMessages,
+    answerBranches,
+    answerRemoteBranches,
+    answerWorktreeFiles,
+    answerIndexFiles,
+    answerRepositoryFiles,
+    answerRemoteRepositoryFiles,
   } = useContext(QuizContext)
 
   const quizType = "user"
@@ -520,6 +527,20 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     }
   }
 
+  const handleAnswerQuiz = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault
+    const aa = branches.filter(branch => branch.branchName)
+    const bb = answerBranches.filter(branch => branch.branchName)
+
+    aa.every(branch => bb.some(ansBranch => ansBranch.branchName === branch.branchName))
+    ? console.log("branch正解!")
+    : console.log("branch不正解!")
+
+    worktreeFiles.every(worktreeFile => answerWorktreeFiles.some(ansWorktreeFile => ansWorktreeFile.fileName === worktreeFile.fileName && ansWorktreeFile.textStatus === worktreeFile.textStatus))
+    ? console.log("work正解!")
+    : console.log("work不正解!")
+  }
+
   const blankCheck = (str :string) => /[^\s]+/g.test(str)
   const removeButtonDisabled = !blankCheck(quizTitle) || !blankCheck(quizIntroduction) || !blankCheck(quizType) || gitInit === "not a git repository" ? true : false
 
@@ -587,6 +608,20 @@ const CreateOrUpdateQuizButton: React.FC = () => {
           onClick={handleUpdateQuizData}
         >
         Submit
+      </Button>
+      }
+    {location.pathname === (`/quiz/answer/${id}`)  &&
+      <Button
+          type="submit"
+          variant="contained"
+          size="large"
+          fullWidth
+          color="default"
+          disabled={removeButtonDisabled}
+          className={classes.submitBtn}
+          onClick={handleAnswerQuiz}
+        >
+        check the answer!
       </Button>
       }
     </>

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -536,19 +536,30 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     }
 
     const checkTheAnswer = (objs :any) => (prop1 :string, prop2 :string, prop3 :string) => (answerObjs :any) =>
-    answerObjs.every((answerObj :any) => objs.some((obj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
-    && objs.every((obj :any) => answerObjs.some((answerObj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
+      answerObjs.every((answerObj :any) => objs.some((obj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
+      && objs.every((obj :any) => answerObjs.some((answerObj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
 
-    // 空白問題を解決する必要あり。
-    // どこで空白を削除するか検討中。
-    // const removeEmptyArray = (objs :any, prop :string) => objs.filter((obj :any) => obj?.[prop])
+    const removeEmptyArray = (objs :any, prop :string) => objs.filter((obj :any) => obj?.[prop])
 
-    checkTheAnswer(branches)("branchName", "", "")(answerBranches)
-    && checkTheAnswer(worktreeFiles)("fileName", "textStatus", "parentBranch")(answerWorktreeFiles)
-    && checkTheAnswer(indexFiles)("fileName", "textStatus", "parentBranch")(answerIndexFiles)
-    && checkTheAnswer(repositoryFiles)("fileName", "textStatus", "parentBranch")(answerRepositoryFiles)
-    && checkTheAnswer(remoteBranches)("remoteBranchName", "", "")(answerRemoteBranches)
-    && checkTheAnswer(remoteRepositoryFiles)("fileName", "textStatus", "parentBranch")(answerRemoteRepositoryFiles)
+    const removeEmptyBranches = removeEmptyArray(branches, "branchName")
+    const removeEmptyAnsBranches = removeEmptyArray(answerBranches, "branchName")
+    const removeEmptyWorktreeFiles = removeEmptyArray(worktreeFiles, "fileName")
+    const removeEmptyAnswerWorktreeFiles = removeEmptyArray(answerWorktreeFiles, "fileName")
+    const removeEmptyIndexFiles = removeEmptyArray(indexFiles, "fileName")
+    const removeEmptyAnswerIndexFiles = removeEmptyArray(answerIndexFiles, "fileName")
+    const removeEmptyRepositoryFiles = removeEmptyArray(repositoryFiles, "fileName")
+    const removeEmptyAnswerRepositoryFiles = removeEmptyArray(answerRepositoryFiles, "fileName")
+    const removeEmptyRemoteBranch = removeEmptyArray(remoteBranches, "remoteBranchName")
+    const removeEmptyAnsRemoteBranch = removeEmptyArray(answerRemoteBranches, "remoteBranchName")
+    const removeEmptyRemoteRepositoryFiles = removeEmptyArray(remoteRepositoryFiles, "fileName")
+    const removeEmptyAnswerRemoteRepositoryFiles = removeEmptyArray(answerRemoteRepositoryFiles, "fileName")
+
+    checkTheAnswer(removeEmptyBranches)("branchName", "", "")(removeEmptyAnsBranches)
+    && checkTheAnswer(removeEmptyWorktreeFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerWorktreeFiles)
+    && checkTheAnswer(removeEmptyIndexFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerIndexFiles)
+    && checkTheAnswer(removeEmptyRepositoryFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerRepositoryFiles)
+    && checkTheAnswer(removeEmptyRemoteBranch)("remoteBranchName", "", "")(removeEmptyAnsRemoteBranch)
+    && checkTheAnswer(removeEmptyRemoteRepositoryFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerRemoteRepositoryFiles)
     ? createQuizAnswerRecord(quizAnswerRecordData)
     : console.log("不正解!")
   }

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -15,6 +15,7 @@ import { createQuizRemoteRepositoryFile, deleteQuizRemoteRepositoryFile } from "
 import { createQuizRemoteCommitMessage, deleteQuizRemoteCommitMessage } from "lib/api/quiz_remote_commit_messages";
 import { AuthContext } from "App";
 import { useHistory, useLocation, useParams } from "react-router-dom";
+import { createQuizAnswerRecord } from "lib/api/quiz_answer_records";
 
 const useStyles = makeStyles((theme: Theme) => ({
   submitBtn: {
@@ -529,6 +530,11 @@ const CreateOrUpdateQuizButton: React.FC = () => {
   const handleAnswerQuiz = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault
 
+    const quizAnswerRecordData = {
+      userId: Number(currentUser?.id),
+      quizId: Number(id)
+    }
+
     const checkTheAnswer = (objs :any) => (prop1 :string, prop2 :string, prop3 :string) => (answerObjs :any) =>
     answerObjs.every((answerObj :any) => objs.some((obj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
     && objs.every((obj :any) => answerObjs.some((answerObj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
@@ -543,7 +549,7 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     && checkTheAnswer(repositoryFiles)("fileName", "textStatus", "parentBranch")(answerRepositoryFiles)
     && checkTheAnswer(remoteBranches)("remoteBranchName", "", "")(answerRemoteBranches)
     && checkTheAnswer(remoteRepositoryFiles)("fileName", "textStatus", "parentBranch")(answerRemoteRepositoryFiles)
-    ? console.log("正解!")
+    ? createQuizAnswerRecord(quizAnswerRecordData)
     : console.log("不正解!")
   }
 

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -16,6 +16,7 @@ import { createQuizRemoteCommitMessage, deleteQuizRemoteCommitMessage } from "li
 import { AuthContext } from "App";
 import { useHistory, useLocation, useParams } from "react-router-dom";
 import { createQuizAnswerRecord } from "lib/api/quiz_answer_records";
+import { getUserQuizzes } from "lib/api/users";
 
 const useStyles = makeStyles((theme: Theme) => ({
   submitBtn: {
@@ -527,7 +528,7 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     }
   }
 
-  const handleAnswerQuiz = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleAnswerQuiz = async(e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault
 
     const quizAnswerRecordData = {
@@ -554,14 +555,23 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     const removeEmptyRemoteRepositoryFiles = removeEmptyArray(remoteRepositoryFiles, "fileName")
     const removeEmptyAnswerRemoteRepositoryFiles = removeEmptyArray(answerRemoteRepositoryFiles, "fileName")
 
-    checkTheAnswer(removeEmptyBranches)("branchName", "", "")(removeEmptyAnsBranches)
-    && checkTheAnswer(removeEmptyWorktreeFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerWorktreeFiles)
-    && checkTheAnswer(removeEmptyIndexFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerIndexFiles)
-    && checkTheAnswer(removeEmptyRepositoryFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerRepositoryFiles)
-    && checkTheAnswer(removeEmptyRemoteBranch)("remoteBranchName", "", "")(removeEmptyAnsRemoteBranch)
-    && checkTheAnswer(removeEmptyRemoteRepositoryFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerRemoteRepositoryFiles)
-    ? createQuizAnswerRecord(quizAnswerRecordData)
-    : console.log("不正解!")
+
+    if (
+      checkTheAnswer(removeEmptyBranches)("branchName", "", "")(removeEmptyAnsBranches)
+      && checkTheAnswer(removeEmptyWorktreeFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerWorktreeFiles)
+      && checkTheAnswer(removeEmptyIndexFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerIndexFiles)
+      && checkTheAnswer(removeEmptyRepositoryFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerRepositoryFiles)
+      && checkTheAnswer(removeEmptyRemoteBranch)("remoteBranchName", "", "")(removeEmptyAnsRemoteBranch)
+      && checkTheAnswer(removeEmptyRemoteRepositoryFiles)("fileName", "textStatus", "parentBranch")(removeEmptyAnswerRemoteRepositoryFiles)
+    ) {
+      const res = await getUserQuizzes(currentUser?.id)
+
+      !res.data.dataAnswerRecords.some((answerRecords :any) => answerRecords.userId === Number(currentUser?.id) && answerRecords.quizId === Number(id))
+      ? console.log(createQuizAnswerRecord(quizAnswerRecordData))
+      : alert("正解!")
+    } else {
+      console.log("不正解!")
+    }
   }
 
   const blankCheck = (str :string) => /[^\s]+/g.test(str)

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -15,7 +15,6 @@ import { createQuizRemoteRepositoryFile, deleteQuizRemoteRepositoryFile } from "
 import { createQuizRemoteCommitMessage, deleteQuizRemoteCommitMessage } from "lib/api/quiz_remote_commit_messages";
 import { AuthContext } from "App";
 import { useHistory, useLocation, useParams } from "react-router-dom";
-import { execPath } from "process";
 
 const useStyles = makeStyles((theme: Theme) => ({
   submitBtn: {
@@ -529,16 +528,23 @@ const CreateOrUpdateQuizButton: React.FC = () => {
 
   const handleAnswerQuiz = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault
-    const aa = branches.filter(branch => branch.branchName)
-    const bb = answerBranches.filter(branch => branch.branchName)
 
-    aa.every(branch => bb.some(ansBranch => ansBranch.branchName === branch.branchName))
-    ? console.log("branch正解!")
-    : console.log("branch不正解!")
+    const checkTheAnswer = (objs :any) => (prop1 :string, prop2 :string, prop3 :string) => (answerObjs :any) =>
+    answerObjs.every((answerObj :any) => objs.some((obj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
+    && objs.every((obj :any) => answerObjs.some((answerObj :any) => obj?.[prop1] === answerObj?.[prop1] && obj?.[prop2] === answerObj?.[prop2] && obj?.[prop3] === answerObj?.[prop3]))
 
-    worktreeFiles.every(worktreeFile => answerWorktreeFiles.some(ansWorktreeFile => ansWorktreeFile.fileName === worktreeFile.fileName && ansWorktreeFile.textStatus === worktreeFile.textStatus))
-    ? console.log("work正解!")
-    : console.log("work不正解!")
+    // 空白問題を解決する必要あり。
+    // どこで空白を削除するか検討中。
+    // const removeEmptyArray = (objs :any, prop :string) => objs.filter((obj :any) => obj?.[prop])
+
+    checkTheAnswer(branches)("branchName", "", "")(answerBranches)
+    && checkTheAnswer(worktreeFiles)("fileName", "textStatus", "parentBranch")(answerWorktreeFiles)
+    && checkTheAnswer(indexFiles)("fileName", "textStatus", "parentBranch")(answerIndexFiles)
+    && checkTheAnswer(repositoryFiles)("fileName", "textStatus", "parentBranch")(answerRepositoryFiles)
+    && checkTheAnswer(remoteBranches)("remoteBranchName", "", "")(answerRemoteBranches)
+    && checkTheAnswer(remoteRepositoryFiles)("fileName", "textStatus", "parentBranch")(answerRemoteRepositoryFiles)
+    ? console.log("正解!")
+    : console.log("不正解!")
   }
 
   const blankCheck = (str :string) => /[^\s]+/g.test(str)

--- a/frontend/app/src/components/pages/UserQuizzes.tsx
+++ b/frontend/app/src/components/pages/UserQuizzes.tsx
@@ -84,6 +84,18 @@ const UserQuizzes: React.FC = () => {
         >
           初期値を編集
         </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          size="large"
+          fullWidth
+          color="default"
+          className={classes.submitBtn}
+          component={Link}
+          to={`/quiz/answer/${userQuiz.id}`}
+        >
+          解答する
+        </Button>
       </>
       ))}
     </>

--- a/frontend/app/src/interfaces/index.ts
+++ b/frontend/app/src/interfaces/index.ts
@@ -135,3 +135,8 @@ export interface CreateQuizRemoteRepositoryFileData {
   quizRemoteRepositoryFileTextStatus: string
   quizRemoteCommitMessageId: number
 }
+
+export interface createQuizAnswerRecordData {
+  userId: number
+  quizId: number
+}

--- a/frontend/app/src/lib/api/quiz_answer_records.ts
+++ b/frontend/app/src/lib/api/quiz_answer_records.ts
@@ -1,0 +1,6 @@
+import { createQuizAnswerRecordData } from "interfaces"
+import client from "lib/api/client"
+
+export const createQuizAnswerRecord = (data: createQuizAnswerRecordData) => {
+  return client.post("quiz_answer_records", data)
+}


### PR DESCRIPTION
概要
--
close #9 

行ったこと
--
・解答用の配列と正解の配列のブランチ名/ファイル名/ファイルのtextStatus/parentBranchの値が一致しているか判別する機能
・正解した場合、quiz_answer_recordsテーブルに正解したuserと答えたquizのidが登録される処理
・追加したquiz_answer_recordsのテスト

行わなかったこと・その理由
--
・クイズの正解を判別する対象にcommit_messageを入れていないこと
理由:
ファイル名やファイル内のtextStatusの値を変更するcommit回数などは人によって変わるため、コミットメッセージの数と文章が一字一句変わらないかを判別すると正解に辿り着くまでの労力が急増するため。
また理想のコミット数や文章はあると思うが、git-used-toはコマンドの使い方を覚えて実践でつまづくことなくgitを使用してもらうことが目的のため今回はクイズの正解を判別する対象にcommit_messageを入れていない。