### PR TITLE
handleCreateQuizSubmitメソッドの処理修正 

### DIFF
--- a/backend/app/controllers/api/v1/quiz_first_or_lasts_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_first_or_lasts_controller.rb
@@ -1,17 +1,36 @@
 class Api::V1::QuizFirstOrLastsController < ApplicationController
   before_action :set_quiz_first_or_last, only: [:show, :destroy]
-  before_action :quiz_first_or_last_params, only: [:create]
+  # before_action :quiz_first_or_last_params, only: [:create]
 
   def create
-    quiz_first_or_last = QuizFirstOrLast.new(quiz_first_or_last_params)
-    if quiz_first_or_last.save
-      render json: {
-        status: 'SUCCESS',
-        data: quiz_first_or_last,
-      }
-    else
-      render json: quiz_first_or_last.errors
+    quiz_first_or_last_hash = []
+    params.require(:_json).map do |param|
+      quiz_first_or_last = QuizFirstOrLast.new(
+        param.permit(
+          :quiz_first_or_last_status,
+          :quiz_id,
+        ).to_h
+      )
+      if quiz_first_or_last.save
+        quiz_first_or_last_hash.push(quiz_first_or_last)
+      else
+        render json: quiz_first_or_last.errors
+        return
+      end
     end
+    render json: {
+      status: 'SUCCESS',
+      data: quiz_first_or_last_hash,
+    }
+    # quiz_first_or_last = QuizFirstOrLast.new(quiz_first_or_last_params)
+    # if quiz_first_or_last.save
+    #   render json: {
+    #     status: 'SUCCESS',
+    #     data: quiz_first_or_last,
+    #   }
+    # else
+    #   render json: quiz_first_or_last.errors
+    # end
   end
 
   def show
@@ -40,7 +59,7 @@ class Api::V1::QuizFirstOrLastsController < ApplicationController
     @quiz_first_or_last = QuizFirstOrLast.find(params[:id])
   end
 
-  def quiz_first_or_last_params
-    params.require(:quiz_first_or_last).permit(:quiz_first_or_last_status, :quiz_id)
-  end
+  # def quiz_first_or_last_params
+  #   params.require(:quiz_first_or_last).permit(:quiz_first_or_last_status, :quiz_id)
+  # end
 end

--- a/backend/spec/requests/api/v1/quiz_first_or_lasts_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_first_or_lasts_spec.rb
@@ -6,22 +6,55 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
   let!(:first_or_last2) { create(:quiz_first_or_last) }
   let(:param) do
     {
-      quiz_first_or_last: {
-        quiz_first_or_last_status: "作成確認用",
-        quiz_id: quiz.id,
-      },
+      _json: [
+        {
+          quiz_first_or_last_status: "作成確認用",
+          quiz_id: quiz.id,
+        },
+      ],
+    }
+  end
+  let(:mulch_params) do
+    {
+      _json: [
+        {
+          quiz_first_or_last_status: "作成確認用2",
+          quiz_id: quiz.id,
+        },
+        {
+          quiz_first_or_last_status: "作成確認用3",
+          quiz_id: quiz.id,
+        },
+      ],
     }
   end
 
   describe "POST /create" do
-    it "quiz_first_or_lastデータの作成が成功すること" do
-      expect do
-        post api_v1_quiz_first_or_lasts_path, params: param
-      end.to change(QuizFirstOrLast, :count).by(+1)
-      res = JSON.parse(response.body)
-      expect(res["status"]).to eq("SUCCESS")
-      expect(res["data"]["quiz_first_or_last_status"]).to eq("作成確認用")
-      expect(response).to have_http_status(:success)
+    context "送られてきた配列内の情報が一つの場合" do
+      it "quiz_first_or_lastデータの作成が成功すること" do
+        expect do
+          post api_v1_quiz_first_or_lasts_path, params: param
+        end.to change(QuizFirstOrLast, :count).by(+1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["data"][0]["quiz_first_or_last_status"]).to eq("作成確認用")
+        expect(res["data"].length).to eq 1
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "送られてきた配列内の情報が2つの場合" do
+      it "quiz_first_or_lastデータの作成が成功すること" do
+        expect do
+          post api_v1_quiz_first_or_lasts_path, params: mulch_params
+        end.to change(QuizFirstOrLast, :count).by(+2)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["data"][0]["quiz_first_or_last_status"]).to eq("作成確認用2")
+        expect(res["data"][1]["quiz_first_or_last_status"]).to eq("作成確認用3")
+        expect(res["data"].length).to eq 2
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -84,7 +84,6 @@ const App: React.FC = () => {
                 <Route exact path="/quiz" component={CreateQuiz} />
                 <Route path="/quiz/edit/:id" component={CreateQuiz} />
                 <Route path="/quiz/init/edit/:id" component={CreateQuiz} />
-                <Route path="/quiz/init/:id" component={CreateQuiz} />
                 <Route path="/quiz/answer/:id" component={CreateQuiz} />
               </Switch>
             </Private>

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -673,8 +673,6 @@ const CreateQuiz: React.FC = () => {
 
   const handleGetQuizData = async (quizFirstOrLastStatus :number) => {
     try {
-      setGitInit("Initialized empty Git repository")
-
       const ResQuiz = await getQuiz(Number(id))
 
       setQuizTitle(ResQuiz.data.quizData.quizTitle)
@@ -683,10 +681,13 @@ const CreateQuiz: React.FC = () => {
       const ResQuizOfLast = await getQuizFirstOrLast(ResQuiz.data.quizFirstOrLastsData[quizFirstOrLastStatus].id)
       setQuizFirstOrLastId(ResQuiz.data.quizFirstOrLastsData[quizFirstOrLastStatus].id)
 
-      setCurrentBranch({
-        currentBranchName: ResQuizOfLast.data.dataBranches[0].quizBranchName,
-        currentBranchId: ResQuizOfLast.data.dataBranches[0].id
-      })
+      if (ResQuizOfLast.data.dataBranches[0]) {
+        setGitInit("Initialized empty Git repository")
+        setCurrentBranch({
+          currentBranchName: ResQuizOfLast.data.dataBranches[0].quizBranchName,
+          currentBranchId: ResQuizOfLast.data.dataBranches[0].id
+        })
+      }
 
       await Promise.all(
         await ResQuizOfLast.data.dataBranches.map(async (branch :any) => {

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -577,7 +577,14 @@ const CreateOrUpdateQuizButton: React.FC = () => {
 
   const blankCheck = (str :string) => /[^\s]+/g.test(str)
 
-  const removeButtonDisabled = !blankCheck(quizTitle) || !blankCheck(quizIntroduction) || !blankCheck(quizType) || gitInit === "not a git repository" ? true : false
+  const removeButtonDisabled =
+    !blankCheck(quizTitle)
+    || !blankCheck(quizIntroduction)
+    || !blankCheck(quizType)
+    || quizIntroduction.length < 30
+    || gitInit === "not a git repository"
+    ? true
+    : false
 
   return(
     <>

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -81,24 +81,25 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     try {
       const aboutQuizRes = await createQuiz(aboutQuizData)
 
-      const quizFirtsOrLastData: QuizFirtsOrLastData | undefined =
-      location.pathname === "/quiz"
-      ? {
-          quizFirstOrLastStatus: "last",
-          quizId: aboutQuizRes?.data.data.id
-        }
-      : location.pathname === (`/quiz/init/${id}`)
-      ? {
-          quizFirstOrLastStatus: "first",
-          quizId: id
-        }
-      : undefined
+      const quizFirtsOrLastData: any =
+        location.pathname === "/quiz"
+        ? [
+            {
+              quizFirstOrLastStatus: "last",
+              quizId: aboutQuizRes?.data.data.id
+            },
+            {
+              quizFirstOrLastStatus: "first",
+              quizId: aboutQuizRes?.data.data.id
+            }
+          ]
+        : undefined
 
       const quizFirtsOrLastRes = await createQuizFirstOrLast(quizFirtsOrLastData)
 
       const quizBranchData = argBranches.map((branch :any) => ({
         quizBranchName: branch.branchName,
-        quizFirstOrLastId: location.pathname === "/quiz" || location.pathname === (`/quiz/init/${id}`) ? quizFirtsOrLastRes?.data.data.id : quizFirstOrLastId
+        quizFirstOrLastId: location.pathname === "/quiz" ? quizFirtsOrLastRes?.data.data[0].id : quizFirstOrLastId
       }))
 
       const quizBranchRes = await createQuizBranch(quizBranchData)
@@ -210,7 +211,7 @@ const CreateOrUpdateQuizButton: React.FC = () => {
         .filter((branch :any) => branch.remoteBranchName)
         .map((branch :any) => ({
           quizRemoteBranchName: branch.remoteBranchName,
-          quizFirstOrLastId: quizFirtsOrLastRes === undefined ? quizFirstOrLastId : quizFirtsOrLastRes.data.data.id
+          quizFirstOrLastId: quizFirtsOrLastRes === undefined ? quizFirstOrLastId : quizFirtsOrLastRes.data.data[0].id
         }
       ))
 
@@ -575,6 +576,7 @@ const CreateOrUpdateQuizButton: React.FC = () => {
   }
 
   const blankCheck = (str :string) => /[^\s]+/g.test(str)
+
   const removeButtonDisabled = !blankCheck(quizTitle) || !blankCheck(quizIntroduction) || !blankCheck(quizType) || gitInit === "not a git repository" ? true : false
 
   return(
@@ -600,31 +602,6 @@ const CreateOrUpdateQuizButton: React.FC = () => {
             remoteCommitMessages,
             remoteRepositoryFiles
             )}
-        >
-        Submit
-      </Button>
-      }
-    {location.pathname === (`/quiz/init/${id}`) &&
-      <Button
-          type="submit"
-          variant="contained"
-          size="large"
-          fullWidth
-          color="default"
-          className={classes.submitBtn}
-          disabled={gitInit === "not a git repository" ? true : false}
-          onClick={
-            handleCreateQuizSubmit(
-              branches,
-              worktreeFiles,
-              indexFiles,
-              commitMessages,
-              fileHistoryForCansellCommits,
-              repositoryFiles,
-              remoteBranches,
-              remoteCommitMessages,
-              remoteRepositoryFiles
-              )}
         >
         Submit
       </Button>

--- a/frontend/app/src/components/pages/UserQuizzes.tsx
+++ b/frontend/app/src/components/pages/UserQuizzes.tsx
@@ -68,18 +68,6 @@ const UserQuizzes: React.FC = () => {
           color="default"
           className={classes.submitBtn}
           component={Link}
-          to={`/quiz/init/${userQuiz.id}`}
-        >
-          初期値を設定
-        </Button>
-        <Button
-          type="submit"
-          variant="contained"
-          size="large"
-          fullWidth
-          color="default"
-          className={classes.submitBtn}
-          component={Link}
           to={`/quiz/init/edit/${userQuiz.id}`}
         >
           初期値を編集


### PR DESCRIPTION
概要
--
close #11 

行ったこと
--
・handleCreateQuizSubmitメソッドでquizFirstOrLastのquizFirstOrLastStatusがfirstのデータも同時に作成する処理を追加
・firstのデータを作成するためのpathの"/quiz/init/:id"を削除し、関連する記述を削除。
・quiz_first_or_lasts_controller.rbのcreateアクションで配列のデータを保存できる様に修正。
・createアクションの記述変更に伴い、テストも修正。

行わなかったこと・その理由
--
特になし
