### PR TITLE
リモート関連のコマンドの処理を追加

### DIFF
--- a/backend/app/controllers/api/v1/quiz_first_or_lasts_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_first_or_lasts_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::QuizFirstOrLastsController < ApplicationController
   before_action :set_quiz_first_or_last, only: [:show, :destroy]
-  # before_action :quiz_first_or_last_params, only: [:create]
 
   def create
     quiz_first_or_last_hash = []
@@ -22,15 +21,6 @@ class Api::V1::QuizFirstOrLastsController < ApplicationController
       status: 'SUCCESS',
       data: quiz_first_or_last_hash,
     }
-    # quiz_first_or_last = QuizFirstOrLast.new(quiz_first_or_last_params)
-    # if quiz_first_or_last.save
-    #   render json: {
-    #     status: 'SUCCESS',
-    #     data: quiz_first_or_last,
-    #   }
-    # else
-    #   render json: quiz_first_or_last.errors
-    # end
   end
 
   def show
@@ -58,8 +48,4 @@ class Api::V1::QuizFirstOrLastsController < ApplicationController
   def set_quiz_first_or_last
     @quiz_first_or_last = QuizFirstOrLast.find(params[:id])
   end
-
-  # def quiz_first_or_last_params
-  #   params.require(:quiz_first_or_last).permit(:quiz_first_or_last_status, :quiz_id)
-  # end
 end

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -27,6 +27,8 @@ export const QuizContext = createContext({} as {
   setAddText :React.Dispatch<React.SetStateAction<string>>
   gitInit: string
   setGitInit :React.Dispatch<React.SetStateAction<string>>
+  remoteAdd: string
+  setRemoteAdd :React.Dispatch<React.SetStateAction<string>>
 
   currentBranch: {
     currentBranchName: string
@@ -415,6 +417,7 @@ const CreateQuiz: React.FC = () => {
   const [text, setText] = useState("");
   const [addText, setAddText] = useState("");
   const [gitInit, setGitInit] = useState<string>("not a git repository")
+  const [remoteAdd, setRemoteAdd] = useState<string>("not added remote")
   const [currentBranch, setCurrentBranch] = useState({
     currentBranchName: "",
     currentBranchId : ""
@@ -961,6 +964,7 @@ const CreateQuiz: React.FC = () => {
         text, setText,
         addText, setAddText,
         gitInit,setGitInit,
+        remoteAdd, setRemoteAdd,
         currentBranch, setCurrentBranch,
         branches, setBranches,
         remoteBranches, setRemoteBranches,

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -812,6 +812,7 @@ const CreateQuiz: React.FC = () => {
           )
         })
       })
+      if (ResQuizOfLast.data.dataRemoteBranches[0]) setRemoteAdd("added remote")
     } catch (err) {
       console.log(err)
     }
@@ -954,6 +955,10 @@ const CreateQuiz: React.FC = () => {
   useEffect(() => {
     console.log("answerRemoteRepositoryFiles", answerRemoteRepositoryFiles)
   },[answerRemoteRepositoryFiles])
+
+  useEffect(() => {
+    console.log("remoteadd", remoteAdd)
+  },[remoteAdd])
 
   return(
     <QuizContext.Provider

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { QuizContext } from "./CreateQuiz";
 import { Button, makeStyles, Theme } from "@material-ui/core"
-import { AboutQuizData, QuizFirtsOrLastData } from "interfaces";
+import { AboutQuizData } from "interfaces";
 import { createQuiz } from "lib/api/quizzes";
 import { createQuizFirstOrLast } from "lib/api/quiz_first_or_lasts";
 import { createQuizBranch, deleteQuizBranch, updateQuizBranch } from "lib/api/quiz_branches";
@@ -529,8 +529,7 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     }
   }
 
-  const handleAnswerQuiz = async(e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault
+  const handleAnswerQuiz = async() => {
 
     const quizAnswerRecordData = {
       userId: Number(currentUser?.id),
@@ -555,7 +554,6 @@ const CreateOrUpdateQuizButton: React.FC = () => {
     const removeEmptyAnsRemoteBranch = removeEmptyArray(answerRemoteBranches, "remoteBranchName")
     const removeEmptyRemoteRepositoryFiles = removeEmptyArray(remoteRepositoryFiles, "fileName")
     const removeEmptyAnswerRemoteRepositoryFiles = removeEmptyArray(answerRemoteRepositoryFiles, "fileName")
-
 
     if (
       checkTheAnswer(removeEmptyBranches)("branchName", "", "")(removeEmptyAnsBranches)

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -394,6 +394,22 @@ const InputCommand: React.FC = () => {
     }
   }
 
+  const gitPushDelete = (text :string, str :number) => {
+    if (remoteBranches.some(remoteBranch => remoteBranch.remoteBranchName === text.substring(str))) {
+      setRemoteBranches(
+        remoteBranches.filter((branch) => branch.remoteBranchName !== text.substring(str))
+      )
+      setRemoteCommitMessages(
+        remoteCommitMessages.filter((commitMessage) => commitMessage.parentRemoteBranch !== text.substring(str))
+      )
+      setRemoteRepositoryFiles(
+        remoteRepositoryFiles.filter((repositoryFile) => repositoryFile.parentRemoteBranch !== text.substring(str))
+      )
+    } else {
+      setAddText(`error: unable to delete '${text.substring(str)}': remote ref does not exist`)
+    }
+  }
+
   const gitBranch = (text :string, str :number) => {
     if (text.substring(str) === "") {
       setAddText('Enter a name after "git branch"')
@@ -977,6 +993,10 @@ const InputCommand: React.FC = () => {
                   gitCommitM(text, 14)
                 } else if (text === `git push origin ${currentBranch.currentBranchName}`) {
                   gitPush()
+                } else if (text.startsWith("git push --delete origin")) {
+                  gitPushDelete(text, 25)
+                } else if (text.startsWith("git push origin :")) {
+                  gitPushDelete(text, 17)
                 } else if (text.startsWith("git branch -m")) {
                   gitBranchM(text, 14)
                 } else if (text.startsWith("git branch -D")) {

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { QuizContext } from "./CreateQuiz";
 import { Input, makeStyles } from "@material-ui/core";
+import { AuthContext } from "App";
 
 const useStyles = makeStyles(() => ({
   input: {
@@ -32,8 +33,11 @@ const InputCommand: React.FC = () => {
     remoteCommitMessages, setRemoteCommitMessages,
     addText, setAddText,
     gitInit, setGitInit,
+    remoteAdd, setRemoteAdd,
     setCommands
   } = useContext(QuizContext)
+
+  const { currentUser } = useContext(AuthContext)
 
   const currentBranchParentWorktreeFiles = worktreeFiles.filter((worktreeFile) => worktreeFile.parentBranch === currentBranch.currentBranchName)
   const currentBranchParentIndexFiles = indexFiles.filter((indexFile) => indexFile.parentBranch === currentBranch.currentBranchName)
@@ -317,74 +321,77 @@ const InputCommand: React.FC = () => {
     const hasNoRemoteCommitMessages = currentBranchParentCommitMessages.filter(commitMessage => !currentBranchParentRemoteCommitMessages.some(remoteCommitMessage => remoteCommitMessage.remoteMessage === commitMessage.message))
     const hasNoRemoteRepositoryFiles = currentBranchParentRepositoryFiles.filter(repositoryFile => !currentBranchParentRemoteRepositoryFiles.some(remoteRepositoryFile => repositoryFile.fileName === remoteRepositoryFile.fileName))
     const rmRemoteRepositoryFiles = currentBranchParentRemoteRepositoryFiles.filter(remoteRepositoryFile => !currentBranchParentRepositoryFiles.some(repositoryFile => repositoryFile.fileName === remoteRepositoryFile.fileName))
-
-    if (!remoteBranches.some(remoteBranch => remoteBranch.remoteBranchName === currentBranch.currentBranchName)) {
-      setRemoteBranches((remoteBranch) => [...remoteBranch,{
-        remoteBranchName: currentBranch.currentBranchName,
-        remoteBranchId: ""
-      }])
-    }
-    rmRemoteRepositoryFiles.forEach(rmRemoteRepositoryFile => {
-      setRemoteRepositoryFiles((repositoryFile) =>
-        repositoryFile.map(repositoryFile =>
-          repositoryFile.parentRemoteBranch === currentBranch.currentBranchName
-          && repositoryFile.fileName === rmRemoteRepositoryFile.fileName
-          ? {
-            fileName: "",
-            textStatus: "",
-            parentRemoteBranch: "",
-            parentRemoteCommitMessage: "",
-            parentRemoteBranchId: "",
-            parentRemoteCommitMessageId: "",
-            remoteRepositoryFileId: ""
-            }
-          : repositoryFile
-        )
-      )
-    })
-    checkExistsRemoteBranches.forEach(remoteBranch => {
-      hasNoRemoteCommitMessages.forEach(hasNoRemoteCommitMessage => {
-        if (remoteBranch.remoteBranchName === hasNoRemoteCommitMessage.parentBranch){
-          setRemoteCommitMessages((commitMessage) => [...commitMessage,{
-            remoteMessage: hasNoRemoteCommitMessage.message,
-            parentRemoteBranch: hasNoRemoteCommitMessage.parentBranch,
-            parentRemoteBranchId: remoteBranch.remoteBranchId,
-            remoteCommitMessageId: ""
-          }])
-        }
-      })
-      differTextStatusRemoteRepositoryFiles.forEach(differTextStatusRemoteRepositoryFile => {
+    if (remoteAdd === "added remote") {
+      if (!remoteBranches.some(remoteBranch => remoteBranch.remoteBranchName === currentBranch.currentBranchName)) {
+        setRemoteBranches((remoteBranch) => [...remoteBranch,{
+          remoteBranchName: currentBranch.currentBranchName,
+          remoteBranchId: ""
+        }])
+      }
+      rmRemoteRepositoryFiles.forEach(rmRemoteRepositoryFile => {
         setRemoteRepositoryFiles((repositoryFile) =>
           repositoryFile.map(repositoryFile =>
-            differTextStatusRemoteRepositoryFile.fileName === repositoryFile.fileName
-            && differTextStatusRemoteRepositoryFile.parentBranch === repositoryFile.parentRemoteBranch
+            repositoryFile.parentRemoteBranch === currentBranch.currentBranchName
+            && repositoryFile.fileName === rmRemoteRepositoryFile.fileName
             ? {
-                fileName: differTextStatusRemoteRepositoryFile.fileName,
-                textStatus: differTextStatusRemoteRepositoryFile.textStatus,
-                parentRemoteBranch: differTextStatusRemoteRepositoryFile.parentBranch,
-                parentRemoteCommitMessage: differTextStatusRemoteRepositoryFile.parentCommitMessage,
-                parentRemoteBranchId: remoteBranch.remoteBranchName === differTextStatusRemoteRepositoryFile.parentBranch ? remoteBranch.remoteBranchId : "",
-                parentRemoteCommitMessageId: "",
-                remoteRepositoryFileId: ""
+              fileName: "",
+              textStatus: "",
+              parentRemoteBranch: "",
+              parentRemoteCommitMessage: "",
+              parentRemoteBranchId: "",
+              parentRemoteCommitMessageId: "",
+              remoteRepositoryFileId: ""
               }
             : repositoryFile
           )
         )
       })
-      hasNoRemoteRepositoryFiles.forEach(hasNoRemoteRepositoryFile => {
-        if (remoteBranch.remoteBranchName === hasNoRemoteRepositoryFile.parentBranch) {
-          setRemoteRepositoryFiles((repositoryFile) => [...repositoryFile,{
-            fileName: hasNoRemoteRepositoryFile.fileName,
-            textStatus: hasNoRemoteRepositoryFile.textStatus,
-            parentRemoteBranch: hasNoRemoteRepositoryFile.parentBranch,
-            parentRemoteCommitMessage: hasNoRemoteRepositoryFile.parentCommitMessage,
-            parentRemoteBranchId: remoteBranch.remoteBranchId,
-            parentRemoteCommitMessageId: "",
-            remoteRepositoryFileId: ""
-          }])
-        }
+      checkExistsRemoteBranches.forEach(remoteBranch => {
+        hasNoRemoteCommitMessages.forEach(hasNoRemoteCommitMessage => {
+          if (remoteBranch.remoteBranchName === hasNoRemoteCommitMessage.parentBranch){
+            setRemoteCommitMessages((commitMessage) => [...commitMessage,{
+              remoteMessage: hasNoRemoteCommitMessage.message,
+              parentRemoteBranch: hasNoRemoteCommitMessage.parentBranch,
+              parentRemoteBranchId: remoteBranch.remoteBranchId,
+              remoteCommitMessageId: ""
+            }])
+          }
+        })
+        differTextStatusRemoteRepositoryFiles.forEach(differTextStatusRemoteRepositoryFile => {
+          setRemoteRepositoryFiles((repositoryFile) =>
+            repositoryFile.map(repositoryFile =>
+              differTextStatusRemoteRepositoryFile.fileName === repositoryFile.fileName
+              && differTextStatusRemoteRepositoryFile.parentBranch === repositoryFile.parentRemoteBranch
+              ? {
+                  fileName: differTextStatusRemoteRepositoryFile.fileName,
+                  textStatus: differTextStatusRemoteRepositoryFile.textStatus,
+                  parentRemoteBranch: differTextStatusRemoteRepositoryFile.parentBranch,
+                  parentRemoteCommitMessage: differTextStatusRemoteRepositoryFile.parentCommitMessage,
+                  parentRemoteBranchId: remoteBranch.remoteBranchName === differTextStatusRemoteRepositoryFile.parentBranch ? remoteBranch.remoteBranchId : "",
+                  parentRemoteCommitMessageId: "",
+                  remoteRepositoryFileId: ""
+                }
+              : repositoryFile
+            )
+          )
+        })
+        hasNoRemoteRepositoryFiles.forEach(hasNoRemoteRepositoryFile => {
+          if (remoteBranch.remoteBranchName === hasNoRemoteRepositoryFile.parentBranch) {
+            setRemoteRepositoryFiles((repositoryFile) => [...repositoryFile,{
+              fileName: hasNoRemoteRepositoryFile.fileName,
+              textStatus: hasNoRemoteRepositoryFile.textStatus,
+              parentRemoteBranch: hasNoRemoteRepositoryFile.parentBranch,
+              parentRemoteCommitMessage: hasNoRemoteRepositoryFile.parentCommitMessage,
+              parentRemoteBranchId: remoteBranch.remoteBranchId,
+              parentRemoteCommitMessageId: "",
+              remoteRepositoryFileId: ""
+            }])
+          }
+        })
       })
-    })
+    } else {
+      setAddText('remote: Repository not found.')
+    }
   }
 
   const gitBranch = (text :string, str :number) => {
@@ -888,6 +895,10 @@ const InputCommand: React.FC = () => {
     }
   }
 
+  const gitRemoteAdd = () => {
+    setRemoteAdd("added remote")
+  }
+
   const gitSetUp = () => {
     setGitInit("Initialized empty Git repository")
     setCurrentBranch({
@@ -952,6 +963,8 @@ const InputCommand: React.FC = () => {
               if (gitInit === "Initialized empty Git repository") {
                 if (text.startsWith("git add .") || text.startsWith("git add -A")){
                   gitAddA()
+                } else if (text === `git remote add https://git-used-to.com/${currentUser?.userName}`){
+                  gitRemoteAdd()
                 } else if (text.startsWith("git add ")){
                   gitAdd(text, 8)
                 } else if (text.startsWith("kakunin")){


### PR DESCRIPTION
概要
--
close #13 

行ったこと
--
・remote addコマンドを叩いているかどうか判別するためのuseStateを作成(useState名:remoteAdd)
※remoteAddの値でremote addコマンドを既に叩いているかを判別する("not added remote"か"added remote")
※初期値は"not added remote"

・クイズを編集/解答する際は、リモートブランチに値が存在する場合に限りremoteAddのuseStateの値を"added remote"に変更する処理をhandleGetQuizDataメソッドに追加

・指定したリモートブランチを削除する"git push --delete origin ブランチ名"か"git push origin :ブランチ名"コマンドを作成


行わなかったこと・理由
--
特になし