### PR TITLE
コメント機能の実装

### DIFF
--- a/backend/app/controllers/api/v1/quiz_comment_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_comment_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::QuizCommentController < ApplicationController
+  def create
+  end
+
+  def show
+  end
+
+  def destroy
+  end
+end

--- a/backend/app/controllers/api/v1/quiz_comment_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_comment_controller.rb
@@ -1,10 +1,44 @@
 class Api::V1::QuizCommentController < ApplicationController
-  def create
+  before_action :quiz_comment_params, only: [:create]
+  before_action :set_quiz_comment, only: [:destroy]
+
+  def index
+    quiz_comments = QuizComment.preload(:quiz)
+    render json: {
+      status: 'SUCCESS',
+      message: 'Loaded quiz comments',
+      data: quiz_comments,
+    }
   end
 
-  def show
+  def create
+    quiz_comments = QuizComment.new(quiz_comment_params)
+    if quiz_comments.save
+      render json: {
+        status: 'SUCCESS',
+        data: quiz_comments,
+      }
+    else
+      render json: quiz_comments.errors
+    end
   end
 
   def destroy
+    quiz_comment = @quiz_comment.destroy
+    render json: {
+      status: 'SUCCESS',
+      message: 'Deleted the quiz comment',
+      data: quiz_comment,
+    }
+  end
+
+  private
+
+  def set_quiz_comment
+    @quiz_comment = QuizComment.find(params[:id])
+  end
+
+  def quiz_comment_params
+    params.require(:quiz_comment).permit(:user_id, :quiz_id, :comment)
   end
 end

--- a/backend/app/controllers/api/v1/quiz_comments_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_comments_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::QuizCommentController < ApplicationController
+class Api::V1::QuizCommentsController < ApplicationController
   before_action :quiz_comment_params, only: [:create]
   before_action :set_quiz_comment, only: [:destroy]
 

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -5,14 +5,12 @@ class Api::V1::UsersController < ApplicationController
   def show
     quizzes = @user.quizzes
     quiz_answer_records = @user.quiz_answer_records
-    quiz_bookmarks = @user.quiz_bookmarks
     quiz_comments = QuizComment.where(quiz_id: @user.quizzes.ids)
     render json: {
       status: 'SUCCESS',
       message: 'Loaded quizzes',
       data: quizzes,
       data_answer_records: quiz_answer_records,
-      data_bookmarks: quiz_bookmarks,
       data_comments: quiz_comments,
     }
   end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -6,12 +6,14 @@ class Api::V1::UsersController < ApplicationController
     quizzes = @user.quizzes
     quiz_answer_records = @user.quiz_answer_records
     quiz_bookmarks = @user.quiz_bookmarks
+    quiz_comments = QuizComment.where(quiz_id: @user.quizzes.ids)
     render json: {
       status: 'SUCCESS',
       message: 'Loaded quizzes',
       data: quizzes,
       data_answer_records: quiz_answer_records,
       data_bookmarks: quiz_bookmarks,
+      data_comments: quiz_comments,
     }
   end
 

--- a/backend/app/models/quiz.rb
+++ b/backend/app/models/quiz.rb
@@ -3,6 +3,7 @@ class Quiz < ApplicationRecord
   has_many :quiz_first_or_lasts, dependent: :destroy
   has_many :quiz_answer_records, dependent: :destroy
   has_many :quiz_bookmarks, dependent: :destroy
+  has_many :quiz_comments, dependent: :destroy
 
   validates :quiz_title, presence: true
   validates :quiz_introduction, presence: true, length: { in: 30..200 }

--- a/backend/app/models/quiz_comment.rb
+++ b/backend/app/models/quiz_comment.rb
@@ -1,0 +1,4 @@
+class QuizComment < ApplicationRecord
+  belongs_to :quiz
+  belongs_to :user
+end

--- a/backend/app/models/quiz_comment.rb
+++ b/backend/app/models/quiz_comment.rb
@@ -1,4 +1,6 @@
 class QuizComment < ApplicationRecord
   belongs_to :quiz
   belongs_to :user
+
+  validates :comment, presence: true, length: { in: 1..100 }
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -11,4 +11,5 @@ class User < ActiveRecord::Base
   has_many :quizzes, dependent: :destroy
   has_many :quiz_answer_records, dependent: :destroy
   has_many :quiz_bookmarks, dependent: :destroy
+  has_many :quiz_comments, dependent: :destroy
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       resources :quizzes, only: %i[index create update show destroy]
       resources :quiz_answer_records, only: %i[create]
       resources :quiz_bookmarks, only: %i[index create destroy]
+      resources :quiz_comments, only: %i[index create destroy]
       resources :quiz_first_or_lasts, only: %i[create show destroy]
       resources :quiz_branches, only: %i[create show update destroy]
       resources :quiz_remote_branches, only: %i[create show destroy]

--- a/backend/db/migrate/20221110105036_create_quiz_comments.rb
+++ b/backend/db/migrate/20221110105036_create_quiz_comments.rb
@@ -1,0 +1,11 @@
+class CreateQuizComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :quiz_comments do |t|
+      t.references :quiz, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :comment, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_102821) do
+ActiveRecord::Schema.define(version: 2022_11_10_105036) do
 
   create_table "quiz_answer_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -36,6 +36,16 @@ ActiveRecord::Schema.define(version: 2022_11_04_102821) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "quiz_first_or_last_id", null: false
     t.index ["quiz_first_or_last_id"], name: "index_quiz_branches_on_quiz_first_or_last_id"
+  end
+
+  create_table "quiz_comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "quiz_id", null: false
+    t.bigint "user_id", null: false
+    t.text "comment", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["quiz_id"], name: "index_quiz_comments_on_quiz_id"
+    t.index ["user_id"], name: "index_quiz_comments_on_user_id"
   end
 
   create_table "quiz_commit_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -172,6 +182,8 @@ ActiveRecord::Schema.define(version: 2022_11_04_102821) do
   add_foreign_key "quiz_bookmarks", "quizzes"
   add_foreign_key "quiz_bookmarks", "users"
   add_foreign_key "quiz_branches", "quiz_first_or_lasts"
+  add_foreign_key "quiz_comments", "quizzes"
+  add_foreign_key "quiz_comments", "users"
   add_foreign_key "quiz_commit_messages", "quiz_branches"
   add_foreign_key "quiz_first_or_lasts", "quizzes"
   add_foreign_key "quiz_history_of_committed_files", "quiz_branches"

--- a/backend/spec/factories/quiz_comments.rb
+++ b/backend/spec/factories/quiz_comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :quiz_comment do
+    quiz { nil }
+    user { nil }
+    comment { "MyText" }
+  end
+end

--- a/backend/spec/factories/quiz_comments.rb
+++ b/backend/spec/factories/quiz_comments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :quiz_comment do
-    quiz { nil }
-    user { nil }
-    comment { "MyText" }
+    quiz { FactoryBot.create(:quiz) }
+    user { FactoryBot.create(:user) }
+    comment { Faker::Alphanumeric.alpha(number: 30) }
   end
 end

--- a/backend/spec/models/quiz_comment_spec.rb
+++ b/backend/spec/models/quiz_comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe QuizComment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/quiz_comment_spec.rb
+++ b/backend/spec/models/quiz_comment_spec.rb
@@ -1,5 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe QuizComment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  def fake_alphanumeric(num)
+    Faker::Alphanumeric.alpha(number: num)
+  end
+
+  def err_message(karam)
+    quiz_comment.errors.messages[karam]
+  end
+
+  describe "validates presence" do
+    context "commentが空の場合" do
+      let(:quiz_comment) { build(:quiz_comment, comment: "") }
+
+      it "エラーになること" do
+        quiz_comment.valid?
+        expect(err_message(:comment)).to include "is too short (minimum is 1 character)"
+      end
+    end
+
+    context "commentの文字数が30文字未満の場合" do
+      let(:quiz_comment) { build(:quiz_comment, comment: fake_alphanumeric(101)) }
+
+      it "エラーになること" do
+        quiz_comment.valid?
+        expect(err_message(:comment)).to include "is too long (maximum is 100 characters)"
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/quiz_comment_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_comment_spec.rb
@@ -1,25 +1,54 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::QuizComments", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/api/v1/quiz_comment/create"
+  let!(:user) { create(:user) }
+  let!(:quiz) { create(:quiz) }
+  let!(:quiz_comment) { create(:quiz_comment) }
+  let!(:quiz_comment2) { create(:quiz_comment) }
+  let(:param) do
+    {
+      quiz_comment: {
+        user_id: user.id,
+        quiz_id: quiz.id,
+        comment: "作成確認用",
+      },
+    }
+  end
+
+  describe "GET /index" do
+    it "全てのquizデータを取得できていること" do
+      get api_v1_quiz_comments_path
+      res = JSON.parse(response.body)
+      expect(res["status"]).to eq("SUCCESS")
+      expect(res["message"]).to eq("Loaded quiz comments")
+      expect(res["data"][0]["id"]).to eq(quiz_comment.id)
+      expect(res["data"][1]["id"]).to eq(quiz_comment2.id)
+      expect(QuizComment.count).to eq 2
+      expect(res["data"].count).to eq 2
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/api/v1/quiz_comment/show"
+  describe "POST /create" do
+    it "quiz_commentデータ作成が成功すること" do
+      expect { post api_v1_quiz_comments_path, params: param }.to change(QuizComment, :count).by(+1)
+      res = JSON.parse(response.body)
+      expect(res["status"]).to eq("SUCCESS")
+      expect(res["data"]["user_id"]).to eq(user.id)
+      expect(res["data"]["quiz_id"]).to eq(quiz.id)
+      expect(res["data"]["comment"]).to eq("作成確認用")
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/api/v1/quiz_comment/destroy"
+  describe "delete /destroy" do
+    it "quizデータの削除が成功すること" do
+      expect { delete api_v1_quiz_comment_path(quiz_comment.id) }.to change(QuizComment, :count).by(-1)
+      res = JSON.parse(response.body)
+      expect(res["status"]).to eq("SUCCESS")
+      expect(res["message"]).to eq("Deleted the quiz comment")
+      expect(res["data"]["id"]).to eq(quiz_comment.id)
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/backend/spec/requests/api/v1/quiz_comment_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_comment_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::QuizComments", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/api/v1/quiz_comment/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/api/v1/quiz_comment/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/api/v1/quiz_comment/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Api::V1::Users", type: :request do
   let!(:not_related_quiz_answer_record) { create(:quiz_answer_record) }
 
   describe "GET /api/v1/users#show" do
+    let!(:quiz_comment) { create(:quiz_comment, quiz:user_quiz1) }
+    let!(:quiz_comment2) { create(:quiz_comment, quiz:user_quiz1, user:user2) }
     context "引数がquizのidの場合" do
       before do
         get api_v1_user_path(user.id)
@@ -36,6 +38,16 @@ RSpec.describe "Api::V1::Users", type: :request do
         expect(res["message"]).to eq("Loaded quizzes")
         expect(res["data_answer_records"][0]["id"]).to eq(related_quiz_answer_record.id)
         expect(res["data_answer_records"].length).to eq 1
+        expect(response).to have_http_status(:success)
+      end
+
+      it "userが作成したquizデータに関連しているcommentのみを取得できること" do
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["message"]).to eq("Loaded quizzes")
+        expect(res["data_comments"][0]["id"]).to eq(quiz_comment.id)
+        expect(res["data_comments"][1]["id"]).to eq(quiz_comment2.id)
+        expect(res["data_comments"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
     end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe "Api::V1::Users", type: :request do
   let!(:not_related_quiz_answer_record) { create(:quiz_answer_record) }
 
   describe "GET /api/v1/users#show" do
-    let!(:quiz_comment) { create(:quiz_comment, quiz:user_quiz1) }
-    let!(:quiz_comment2) { create(:quiz_comment, quiz:user_quiz1, user:user2) }
+    let!(:quiz_comment) { create(:quiz_comment, quiz: user_quiz1) }
+    let!(:quiz_comment2) { create(:quiz_comment, quiz: user_quiz1, user: user2) }
+
     context "引数がquizのidの場合" do
       before do
         get api_v1_user_path(user.id)

--- a/frontend/app/src/components/pages/QuizComment.tsx
+++ b/frontend/app/src/components/pages/QuizComment.tsx
@@ -1,6 +1,7 @@
 import { Button, createStyles, makeStyles, TextField, Theme } from "@material-ui/core"
+import DeleteIcon from '@material-ui/icons/Delete';
 import { AuthContext } from "App"
-import { createQuizComment } from "lib/api/quiz_comments"
+import { createQuizComment, deleteQuizComment } from "lib/api/quiz_comments"
 import { useContext } from "react"
 import { QuizBookmarkContext } from "./QuizList"
 
@@ -35,21 +36,29 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
         comment: quizComment
       }
       const quizCommentRes = await createQuizComment(quizCommentData)
-
       setQuizCommentHistory((commentHistory) => [...commentHistory,{
         id: quizCommentRes.data.data.id,
         quizId: quizCommentRes.data.data.quizId,
         userId:quizCommentRes.data.data.userId,
         comment: quizCommentRes.data.data.comment
       }])
-
       setQuizComment("")
-
       console.log("quizCommentRes", quizCommentRes)
     } catch (err) {
       console.log(err)
     }
   }
+
+  const handleDeleteQuizCommentSubmit = async(e: React.MouseEvent<HTMLButtonElement>,commentId :any) => {
+    try {
+      deleteQuizComment(commentId)
+      setQuizCommentHistory(quizCommentHistory.filter(comment => comment.id !== commentId))
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  const deleteComment = quizCommentHistory.filter(commentHistory =>commentHistory.quizId === quizId)
 
   return(
     <>
@@ -69,7 +78,6 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
         type="submit"
         variant="contained"
         size="large"
-        fullWidth
         color="default"
         disabled={!quizComment}
         className={classes.submitBtn}
@@ -77,6 +85,21 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
         >
         Submit
       </Button>
+      {deleteComment.map(comment =>
+        <p>
+          {comment.comment}
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            color="default"
+            className={classes.submitBtn}
+            onClick={e => handleDeleteQuizCommentSubmit(e, comment.id)}
+            >
+            <DeleteIcon />
+          </Button>
+        </p>
+        )}
     </>
   )
 }

--- a/frontend/app/src/components/pages/QuizComment.tsx
+++ b/frontend/app/src/components/pages/QuizComment.tsx
@@ -69,6 +69,12 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
           label="コメント"
           variant="outlined"
           value={quizComment}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              if (quizComment) handleCreateQuizCommentSubmit()
+            }
+          }}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>{
             setQuizComment(e.target.value)
           }}

--- a/frontend/app/src/components/pages/QuizComment.tsx
+++ b/frontend/app/src/components/pages/QuizComment.tsx
@@ -85,7 +85,7 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
         variant="contained"
         size="large"
         color="default"
-        disabled={!quizComment}
+        disabled={!quizComment || quizComment.length > 100}
         className={classes.submitBtn}
         onClick={handleCreateQuizCommentSubmit}
         >

--- a/frontend/app/src/components/pages/QuizComment.tsx
+++ b/frontend/app/src/components/pages/QuizComment.tsx
@@ -1,0 +1,84 @@
+import { Button, createStyles, makeStyles, TextField, Theme } from "@material-ui/core"
+import { AuthContext } from "App"
+import { createQuizComment } from "lib/api/quiz_comments"
+import { useContext } from "react"
+import { QuizBookmarkContext } from "./QuizList"
+
+const userStyles = makeStyles((theme: Theme) => createStyles({
+  root: {
+    "& .MuiTextField-root": {
+      margin: theme.spacing(1),
+      width: "25ch"
+    }
+  },
+  submitBtn: {
+    marginTop: theme.spacing(2),
+    flexGrow: 1,
+    textTransform: "none",
+    backgroundColor: "#f5f5f5"
+  }
+}))
+
+const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
+  const classes = userStyles()
+  const { currentUser } = useContext(AuthContext)
+  const {
+    quizCommentHistory, setQuizCommentHistory,
+    quizComment, setQuizComment
+  } = useContext(QuizBookmarkContext)
+
+  const handleCreateQuizCommentSubmit = async() => {
+    try {
+      const quizCommentData = {
+        userId: currentUser?.id,
+        quizId: quizId,
+        comment: quizComment
+      }
+      const quizCommentRes = await createQuizComment(quizCommentData)
+
+      setQuizCommentHistory((commentHistory) => [...commentHistory,{
+        id: quizCommentRes.data.data.id,
+        quizId: quizCommentRes.data.data.quizId,
+        userId:quizCommentRes.data.data.userId,
+        comment: quizCommentRes.data.data.comment
+      }])
+
+      setQuizComment("")
+
+      console.log("quizCommentRes", quizCommentRes)
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  return(
+    <>
+      <form className={classes.root} noValidate autoComplete="off">
+        <TextField
+          required
+          id="outlined-required"
+          label="コメント"
+          variant="outlined"
+          value={quizComment}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>{
+            setQuizComment(e.target.value)
+          }}
+        />
+      </form>
+      <Button
+        type="submit"
+        variant="contained"
+        size="large"
+        fullWidth
+        color="default"
+        disabled={!quizComment}
+        className={classes.submitBtn}
+        onClick={handleCreateQuizCommentSubmit}
+        >
+        Submit
+      </Button>
+    </>
+  )
+}
+
+export default QuizComment

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -1,4 +1,4 @@
-import { Button, makeStyles, Modal, Theme } from "@material-ui/core";
+import { Button, makeStyles, Theme } from "@material-ui/core";
 import { AuthContext } from "App";
 import { getAllQuizzes } from "lib/api/quizzes";
 import { getAllQuizBookmarks } from "lib/api/quiz_boolmarks";
@@ -42,16 +42,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
     textTransform: "none",
     backgroundColor: "#f5f5f5"
-  },
-  modal: {
-    backgroundColor: "#f5f5f5",
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'absolute',
-    width: 400,
-    border: '2px solid #000',
-    padding: theme.spacing(2, 4, 3),
   }
 }))
 
@@ -77,7 +67,6 @@ const QuizList: React.FC = () => {
     comment: ""
   }])
   const [quizComment, setQuizComment] = useState("")
-  const [modal, setModal] = useState(false)
 
   const handleGetUserQuizzes = async () => {
     try {
@@ -142,9 +131,6 @@ const QuizList: React.FC = () => {
     }
   }
 
-  const handleModalOpen = () => setModal(true)
-  const handleModalclose = () => setModal(false)
-
   const getBookmarkId = (quizId :string) =>
     quizBookmarks.some(bookmark => bookmark.quizId === quizId && Number(bookmark.userId) === currentUser?.id)
     ? quizBookmarks.filter(bookmark => bookmark.quizId === quizId && Number(bookmark.userId) === currentUser?.id)[0].id
@@ -173,74 +159,63 @@ const QuizList: React.FC = () => {
 
   return (
     <>
-    { quizzes.map((quiz) => (
-      <>
-        <p>{ quiz.id }</p>
-        <p>{ quiz.quizTitle }</p>
-        <p>{ quiz.quizIntroduction }</p>
-        <Button
-          type="submit"
-          variant="contained"
-          size="large"
-          fullWidth
-          color="default"
-          className={classes.submitBtn}
-          component={Link}
-          to={`/quiz/edit/${quiz.id}`}
-        >
-          編集
-        </Button>
-        <Button
-          type="submit"
-          variant="contained"
-          size="large"
-          fullWidth
-          color="default"
-          className={classes.submitBtn}
-          component={Link}
-          to={`/quiz/init/edit/${quiz.id}`}
-        >
-          初期値を編集
-        </Button>
-        <Button
-          type="submit"
-          variant="contained"
-          size="large"
-          fullWidth
-          color="default"
-          className={classes.submitBtn}
-          component={Link}
-          to={`/quiz/answer/${quiz.id}`}
-        >
-          解答する
-        </Button>
-        <QuizBookmarkContext.Provider
-          value={{
-            quizBookmarks, setQuizBookmarks,
-            quizCommentHistory, setQuizCommentHistory,
-            quizComment, setQuizComment
-          }}>
+    <QuizBookmarkContext.Provider
+      value={{
+        quizBookmarks, setQuizBookmarks,
+        quizCommentHistory, setQuizCommentHistory,
+        quizComment, setQuizComment
+      }}>
+      {quizzes.map((quiz) => (
+        <>
+          <p>{ quiz.id }</p>
+          <p>{ quiz.quizTitle }</p>
+          <p>{ quiz.quizIntroduction }</p>
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            fullWidth
+            color="default"
+            className={classes.submitBtn}
+            component={Link}
+            to={`/quiz/edit/${quiz.id}`}
+          >
+            編集
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            fullWidth
+            color="default"
+            className={classes.submitBtn}
+            component={Link}
+            to={`/quiz/init/edit/${quiz.id}`}
+          >
+            初期値を編集
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            fullWidth
+            color="default"
+            className={classes.submitBtn}
+            component={Link}
+            to={`/quiz/answer/${quiz.id}`}
+          >
+            解答する
+          </Button>
           <QuizBookmarkButton
             quizId={Number(quiz.id)}
             bookmarkId={getBookmarkId(quiz.id)}
           />
-          <Button onClick={handleModalOpen}>
-            Open Modal
-          </Button>
-          <Modal
-            open={modal}
-            onClose={handleModalclose}
-            className={classes.modal}
-            aria-labelledby="simple-modal-title"
-            aria-describedby="simple-modal-description"
-          >
-            <QuizComment
-              quizId={Number(quiz.id)}
-            />
-          </Modal>
-        </QuizBookmarkContext.Provider>
-      </>
-      ))}
+          <QuizComment
+            quizId={Number(quiz.id)}
+          />
+        </>
+        ))}
+      </QuizBookmarkContext.Provider>
     </>
   )
 }

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -1,4 +1,4 @@
-import { Button, makeStyles, Theme } from "@material-ui/core";
+import { Button, makeStyles, Modal, Theme } from "@material-ui/core";
 import { AuthContext } from "App";
 import { getAllQuizzes } from "lib/api/quizzes";
 import { getAllQuizBookmarks } from "lib/api/quiz_boolmarks";
@@ -21,15 +21,15 @@ export const QuizBookmarkContext = createContext({} as {
     quizId: string,
   }[]>>
   quizCommentHistory: {
-    id: string,
-    userId: string,
-    quizId: string,
+    id: number,
+    userId: number,
+    quizId: number,
     comment: string
   }[]
   setQuizCommentHistory :React.Dispatch<React.SetStateAction<{
-    id: string,
-    userId: string,
-    quizId: string,
+    id: number,
+    userId: number,
+    quizId: number,
     comment: string
   }[]>>
   quizComment: string
@@ -42,6 +42,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
     textTransform: "none",
     backgroundColor: "#f5f5f5"
+  },
+  modal: {
+    backgroundColor: "#f5f5f5",
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'absolute',
+    width: 400,
+    border: '2px solid #000',
+    padding: theme.spacing(2, 4, 3),
   }
 }))
 
@@ -61,12 +71,13 @@ const QuizList: React.FC = () => {
     quizId: "",
   }])
   const [quizCommentHistory, setQuizCommentHistory] = useState([{
-    id: "",
-    userId: "",
-    quizId: "",
+    id: 0,
+    userId: 0,
+    quizId: 0,
     comment: ""
   }])
   const [quizComment, setQuizComment] = useState("")
+  const [modal, setModal] = useState(false)
 
   const handleGetUserQuizzes = async () => {
     try {
@@ -130,6 +141,14 @@ const QuizList: React.FC = () => {
       console.log(err)
     }
   }
+
+  const handleModalOpen = () => setModal(true)
+  const handleModalclose = () => setModal(false)
+
+  const getBookmarkId = (quizId :string) =>
+    quizBookmarks.some(bookmark => bookmark.quizId === quizId && Number(bookmark.userId) === currentUser?.id)
+    ? quizBookmarks.filter(bookmark => bookmark.quizId === quizId && Number(bookmark.userId) === currentUser?.id)[0].id
+    : undefined
 
   useEffect(() => {
     const currentPath = (path :string) => location.pathname === (path)
@@ -203,15 +222,22 @@ const QuizList: React.FC = () => {
           }}>
           <QuizBookmarkButton
             quizId={Number(quiz.id)}
-            bookmarkId={
-              quizBookmarks.some(bookmark => bookmark.quizId === quiz.id && Number(bookmark.userId) === currentUser?.id)
-              ? quizBookmarks.filter(bookmark => bookmark.quizId === quiz.id && Number(bookmark.userId) === currentUser?.id)[0].id
-              : undefined
-            }
+            bookmarkId={getBookmarkId(quiz.id)}
           />
-          <QuizComment
-            quizId={Number(quiz.id)}
-          />
+          <Button onClick={handleModalOpen}>
+            Open Modal
+          </Button>
+          <Modal
+            open={modal}
+            onClose={handleModalclose}
+            className={classes.modal}
+            aria-labelledby="simple-modal-title"
+            aria-describedby="simple-modal-description"
+          >
+            <QuizComment
+              quizId={Number(quiz.id)}
+            />
+          </Modal>
         </QuizBookmarkContext.Provider>
       </>
       ))}

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -2,10 +2,12 @@ import { Button, makeStyles, Theme } from "@material-ui/core";
 import { AuthContext } from "App";
 import { getAllQuizzes } from "lib/api/quizzes";
 import { getAllQuizBookmarks } from "lib/api/quiz_boolmarks";
+import { getAllQuizComments } from "lib/api/quiz_comments";
 import { getUserQuizzes } from "lib/api/users"
 import React, { useContext, useState, useEffect, createContext } from "react";
 import { Link, useLocation } from "react-router-dom";
 import QuizBookmarkButton from "./QuizBookmarkButton";
+import QuizComment from "./QuizComment";
 
 export const QuizBookmarkContext = createContext({} as {
   quizBookmarks: {
@@ -18,6 +20,20 @@ export const QuizBookmarkContext = createContext({} as {
     userId: string,
     quizId: string,
   }[]>>
+  quizCommentHistory: {
+    id: string,
+    userId: string,
+    quizId: string,
+    comment: string
+  }[]
+  setQuizCommentHistory :React.Dispatch<React.SetStateAction<{
+    id: string,
+    userId: string,
+    quizId: string,
+    comment: string
+  }[]>>
+  quizComment: string
+  setQuizComment :React.Dispatch<React.SetStateAction<string>>
 })
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -44,6 +60,13 @@ const QuizList: React.FC = () => {
     userId: "",
     quizId: "",
   }])
+  const [quizCommentHistory, setQuizCommentHistory] = useState([{
+    id: "",
+    userId: "",
+    quizId: "",
+    comment: ""
+  }])
+  const [quizComment, setQuizComment] = useState("")
 
   const handleGetUserQuizzes = async () => {
     try {
@@ -53,6 +76,7 @@ const QuizList: React.FC = () => {
       if (resUserQuizzes?.status === 200) {
         setQuizzes(resUserQuizzes?.data.data)
         setQuizBookmarks(resAllBookmarks?.data.data)
+        setQuizCommentHistory(resUserQuizzes?.data.dataComments)
       } else {
         console.log("No likes")
       }
@@ -65,10 +89,12 @@ const QuizList: React.FC = () => {
     try {
       const resQuizzes = await getAllQuizzes()
       const resAllBookmarks = await getAllQuizBookmarks()
+      const resQuizComments = await getAllQuizComments()
       console.log(resQuizzes)
       if (resQuizzes?.status === 200) {
         setQuizzes(resQuizzes?.data.data)
         setQuizBookmarks(resAllBookmarks?.data.data)
+        setQuizCommentHistory(resQuizComments?.data.data)
       } else {
         console.log("No likes")
       }
@@ -89,8 +115,14 @@ const QuizList: React.FC = () => {
             allBookmarks.some((allBookmark :any) =>
               allBookmark.quizId === res.id)
             )
+        const QuizComments =
+          resUserQuizzes?.data.dataComments.filter((res :any) =>
+            bookmarkedQuizzes.some((allBookmark :any) =>
+              allBookmark.id === res.quizId)
+            )
         setQuizzes(bookmarkedQuizzes)
         setQuizBookmarks(resAllBookmarks?.data.data)
+        setQuizCommentHistory(QuizComments)
       } else {
         console.log("No likes")
       }
@@ -115,6 +147,10 @@ const QuizList: React.FC = () => {
   useEffect(() => {
     console.log("quizBookmarks", quizBookmarks)
   }, [quizBookmarks])
+
+  useEffect(() => {
+    console.log("quizCommentHistory", quizCommentHistory)
+  }, [quizCommentHistory])
 
   return (
     <>
@@ -162,6 +198,8 @@ const QuizList: React.FC = () => {
         <QuizBookmarkContext.Provider
           value={{
             quizBookmarks, setQuizBookmarks,
+            quizCommentHistory, setQuizCommentHistory,
+            quizComment, setQuizComment
           }}>
           <QuizBookmarkButton
             quizId={Number(quiz.id)}
@@ -170,6 +208,9 @@ const QuizList: React.FC = () => {
               ? quizBookmarks.filter(bookmark => bookmark.quizId === quiz.id && Number(bookmark.userId) === currentUser?.id)[0].id
               : undefined
             }
+          />
+          <QuizComment
+            quizId={Number(quiz.id)}
           />
         </QuizBookmarkContext.Provider>
       </>

--- a/frontend/app/src/interfaces/index.ts
+++ b/frontend/app/src/interfaces/index.ts
@@ -147,7 +147,7 @@ export interface createQuizBookmarkData {
 }
 
 export interface createQuizCommentData {
-  userId: number
+  userId: number | undefined
   quizId: number
   comment: string
 }

--- a/frontend/app/src/interfaces/index.ts
+++ b/frontend/app/src/interfaces/index.ts
@@ -145,3 +145,9 @@ export interface createQuizBookmarkData {
   userId: number
   quizId: number
 }
+
+export interface createQuizCommentData {
+  userId: number
+  quizId: number
+  comment: string
+}

--- a/frontend/app/src/lib/api/quiz_comments.ts
+++ b/frontend/app/src/lib/api/quiz_comments.ts
@@ -1,0 +1,14 @@
+import { createQuizCommentData } from "interfaces"
+import client from "lib/api/client"
+
+export const getAllQuizComments = () => {
+  return client.get("quiz_comments")
+}
+
+export const createQuizComment = (data: createQuizCommentData) => {
+  return client.post("quiz_comments", data)
+}
+
+export const deleteQuizComment = (id: number | undefined | null) => {
+  return client.delete(`quiz_comments/${id}`)
+}


### PR DESCRIPTION
概要
--
close #17 

行ったこと
--
■backend
【コメント用のテーブル/controller/model/テストを作成】
コメントは100文字以内でないと保存ができないように設定。

【users_controllerのshowアクションからuserが作成したquizのidに関連しているcommentのデータを取得するように記述】
コメントの情報を取得する場合は、現在下記の二つの場面のみ。
①全てのクイズデータを取得する場合
②userに関連しているクイズデータを取得する場合
そのため、commentのindexアクションの他にuserのshowアクションでコメントのデータを取得できるように記述した。

■frontend
【クイズごとにコメントの作成/削除が行える機能を追加】
現状はクイズの一覧ページでクイズごとにコメントができるフォームとコメントを削除できるボタンを作成。
どこでコメントが行えるようにするかというデザイン面に関しては別のブランチで別の機能も含めてデザインを整えるので見栄えが悪くても期待通りに動作しているため今回のissueは完了としている。

行わなかったこと・理由
--
【デザイン面】
frontendの箇所でコメントしたことと重複するが、デザイン面に関してはデザインを整えるissueをその他の機能開発後に作成して取り組む予定のため、現ブランチでは触れていない。

