### PR TITLE
タグ機能の実装

### DIFF
--- a/backend/app/controllers/api/v1/quiz_tags_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_tags_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::QuizTagsController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/backend/app/controllers/api/v1/quiz_tags_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_tags_controller.rb
@@ -1,7 +1,35 @@
 class Api::V1::QuizTagsController < ApplicationController
+  before_action :quiz_tag_params, only: [:create]
+  before_action :set_quiz_tag, only: [:destroy]
+
   def create
+    quiz_tags = QuizTag.new(quiz_tag_params)
+    if quiz_tags.save
+      render json: {
+        status: 'SUCCESS',
+        data: quiz_tags,
+      }
+    else
+      render json: quiz_tags.errors
+    end
   end
 
   def destroy
+    quiz_tag = @quiz_tag.destroy
+    render json: {
+      status: 'SUCCESS',
+      message: 'Deleted the quiz tag',
+      data: quiz_tag,
+    }
+  end
+
+  private
+
+  def set_quiz_tag
+    @quiz_tag = QuizTag.find(params[:id])
+  end
+
+  def quiz_tag_params
+    params.require(:quiz_tag).permit(:quiz_id, :tag)
   end
 end

--- a/backend/app/controllers/api/v1/quizzes_controller.rb
+++ b/backend/app/controllers/api/v1/quizzes_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::QuizzesController < ApplicationController
-  before_action :set_quiz, only: [:show, :update, :destroy]
+  before_action :set_quiz, only: [:show, :update, :destroy, :tag]
 
   def index
     quizzes = Quiz.preload(:user)
@@ -53,6 +53,15 @@ class Api::V1::QuizzesController < ApplicationController
       status: 'SUCCESS',
       message: 'Deleted the post',
       data: quiz,
+    }
+  end
+
+  def tag
+    quiz_tags = @quiz.quiz_tags
+    render json: {
+      status: 'SUCCESS',
+      message: 'Loaded quiz tags',
+      quiz_tags_data: quiz_tags,
     }
   end
 

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -6,12 +6,14 @@ class Api::V1::UsersController < ApplicationController
     quizzes = @user.quizzes
     quiz_answer_records = @user.quiz_answer_records
     quiz_comments = QuizComment.where(quiz_id: @user.quizzes.ids)
+    quiz_tags = QuizTag.where(quiz_id: @user.quizzes.ids)
     render json: {
       status: 'SUCCESS',
       message: 'Loaded quizzes',
       data: quizzes,
       data_answer_records: quiz_answer_records,
       data_comments: quiz_comments,
+      data_tags: quiz_tags,
     }
   end
 

--- a/backend/app/models/quiz.rb
+++ b/backend/app/models/quiz.rb
@@ -4,6 +4,7 @@ class Quiz < ApplicationRecord
   has_many :quiz_answer_records, dependent: :destroy
   has_many :quiz_bookmarks, dependent: :destroy
   has_many :quiz_comments, dependent: :destroy
+  has_many :quiz_tags, dependent: :destroy
 
   validates :quiz_title, presence: true
   validates :quiz_introduction, presence: true, length: { in: 30..200 }

--- a/backend/app/models/quiz_tag.rb
+++ b/backend/app/models/quiz_tag.rb
@@ -1,0 +1,3 @@
+class QuizTag < ApplicationRecord
+  belongs_to :quiz
+end

--- a/backend/app/models/quiz_tag.rb
+++ b/backend/app/models/quiz_tag.rb
@@ -1,3 +1,5 @@
 class QuizTag < ApplicationRecord
   belongs_to :quiz
+
+  validates :tag, presence: true
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       resources :quiz_answer_records, only: %i[create]
       resources :quiz_bookmarks, only: %i[index create destroy]
       resources :quiz_comments, only: %i[index create destroy]
+      resources :quiz_tags, only: %i[create destroy]
       resources :quiz_first_or_lasts, only: %i[create show destroy]
       resources :quiz_branches, only: %i[create show update destroy]
       resources :quiz_remote_branches, only: %i[create show destroy]

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
       end
 
       resources :users, only: %i[show update]
-      resources :quizzes, only: %i[index create update show destroy]
+      resources :quizzes, only: %i[index create update show destroy] do
+        member do
+          get 'tag'
+        end
+      end
       resources :quiz_answer_records, only: %i[create]
       resources :quiz_bookmarks, only: %i[index create destroy]
       resources :quiz_comments, only: %i[index create destroy]

--- a/backend/db/migrate/20221113123950_create_quiz_tags.rb
+++ b/backend/db/migrate/20221113123950_create_quiz_tags.rb
@@ -1,0 +1,10 @@
+class CreateQuizTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :quiz_tags do |t|
+      t.string :tag
+      t.references :quiz, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_10_105036) do
+ActiveRecord::Schema.define(version: 2022_11_13_123950) do
 
   create_table "quiz_answer_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -126,6 +126,14 @@ ActiveRecord::Schema.define(version: 2022_11_10_105036) do
     t.index ["quiz_commit_message_id"], name: "index_quiz_repository_files_on_quiz_commit_message_id"
   end
 
+  create_table "quiz_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "tag"
+    t.bigint "quiz_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["quiz_id"], name: "index_quiz_tags_on_quiz_id"
+  end
+
   create_table "quiz_worktree_files", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "quiz_branch_id", null: false
     t.string "quiz_worktree_file_name"
@@ -193,6 +201,7 @@ ActiveRecord::Schema.define(version: 2022_11_10_105036) do
   add_foreign_key "quiz_remote_commit_messages", "quiz_remote_branches"
   add_foreign_key "quiz_remote_repository_files", "quiz_remote_commit_messages"
   add_foreign_key "quiz_repository_files", "quiz_commit_messages"
+  add_foreign_key "quiz_tags", "quizzes"
   add_foreign_key "quiz_worktree_files", "quiz_branches"
   add_foreign_key "quizzes", "users"
 end

--- a/backend/spec/factories/quiz_tags.rb
+++ b/backend/spec/factories/quiz_tags.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :quiz_tag do
-    tag { "MyString" }
-    quiz { nil }
+    tag { "add" }
+    quiz { FactoryBot.create(:quiz) }
   end
 end

--- a/backend/spec/factories/quiz_tags.rb
+++ b/backend/spec/factories/quiz_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :quiz_tag do
+    tag { "MyString" }
+    quiz { nil }
+  end
+end

--- a/backend/spec/models/quiz_spec.rb
+++ b/backend/spec/models/quiz_spec.rb
@@ -60,8 +60,11 @@ RSpec.describe Quiz, type: :model do
       let(:quiz) { create(:quiz) }
       let!(:quiz_first_or_last) { create(:quiz_first_or_last, quiz: quiz) }
       let!(:quiz_answer_record) { create(:quiz_answer_record, quiz: quiz) }
+      let!(:quiz_bookmark) { create(:quiz_bookmark, quiz: quiz) }
+      let!(:quiz_comment) { create(:quiz_comment, quiz: quiz) }
+      let!(:quiz_tag) { create(:quiz_tag, quiz: quiz) }
 
-      it "quizに紐づいているquiz_first_or_last/quiz_answer_recordのデータも削除されること" do
+      it "quizに紐づいているquiz_first_or_lastのデータも削除されること" do
         expect do
           quiz.destroy
         end.to change(QuizFirstOrLast, :count).by(-1)
@@ -71,6 +74,24 @@ RSpec.describe Quiz, type: :model do
         expect do
           quiz.destroy
         end.to change(QuizAnswerRecord, :count).by(-1)
+      end
+
+      it "quizに紐づいているquiz_bookmarkのデータも削除されること" do
+        expect do
+          quiz.destroy
+        end.to change(QuizBookmark, :count).by(-1)
+      end
+
+      it "quizに紐づいているquiz_commentのデータも削除されること" do
+        expect do
+          quiz.destroy
+        end.to change(QuizComment, :count).by(-1)
+      end
+
+      it "quizに紐づいているquiz_tagのデータも削除されること" do
+        expect do
+          quiz.destroy
+        end.to change(QuizTag, :count).by(-1)
       end
     end
   end

--- a/backend/spec/models/quiz_tag_spec.rb
+++ b/backend/spec/models/quiz_tag_spec.rb
@@ -1,5 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe QuizTag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  def err_message(karam)
+    quiz_tag.errors.messages[karam]
+  end
+
+  describe "validates presence" do
+    context "tagが空の場合" do
+      let(:quiz_tag) { build(:quiz_tag, tag: "") }
+
+      it "エラーになること" do
+        quiz_tag.valid?
+        expect(err_message(:tag)).to include "can't be blank"
+      end
+    end
+  end
 end

--- a/backend/spec/models/quiz_tag_spec.rb
+++ b/backend/spec/models/quiz_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe QuizTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/requests/api/v1/quiz_answer_records_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_answer_records_spec.rb
@@ -33,14 +33,28 @@ RSpec.describe "Api::V1::QuizAnswerRecords", type: :request do
         expect(res["data"]["user_id"]).to eq(user.id)
         expect(res["data"]["quiz_id"]).to eq(quiz.id)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_answer_records_path, params: param
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "既に同じ値のquiz_answer_recordがDB内に存在する場合" do
       it "データ登録が失敗すること" do
-        post api_v1_quiz_answer_records_path, params: bad_param
+        expect do
+          post api_v1_quiz_answer_records_path, params: bad_param
+        end.to change(QuizAnswerRecord, :count).by(0)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["messaeg"]).to eq("既に解答済みのデータは存在しています。")
+      end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_answer_records_path, params: bad_param
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
       end
     end
   end

--- a/backend/spec/requests/api/v1/quiz_bookmarks_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_bookmarks_spec.rb
@@ -24,8 +24,11 @@ RSpec.describe "Api::V1::QuizBookmarks", type: :request do
   end
 
   describe "GET /index" do
-    it "全てのquiz_bookmarkデータを取得できていること" do
+    before do
       get api_v1_quiz_bookmarks_path
+    end
+
+    it "全てのquiz_bookmarkデータを取得できていること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["message"]).to eq("Loaded quiz bookmarks")
@@ -34,6 +37,11 @@ RSpec.describe "Api::V1::QuizBookmarks", type: :request do
       expect(QuizBookmark.count).to eq 2
       expect(res["data"].count).to eq 2
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 
@@ -48,6 +56,12 @@ RSpec.describe "Api::V1::QuizBookmarks", type: :request do
         expect(res["data"]["user_id"]).to eq(user.id)
         expect(res["data"]["quiz_id"]).to eq(quiz.id)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_bookmarks_path, params: param
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "既に同じ値のquiz_bookmarkがDB内に存在する場合" do
@@ -56,6 +70,12 @@ RSpec.describe "Api::V1::QuizBookmarks", type: :request do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["messaeg"]).to eq("既に解答済みのデータは存在しています。")
+      end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_bookmarks_path, params: bad_param
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
       end
     end
   end
@@ -70,6 +90,12 @@ RSpec.describe "Api::V1::QuizBookmarks", type: :request do
       expect(res["message"]).to eq("Deleted the quiz bookmark")
       expect(res["data"]["id"]).to eq(quiz_bookmark.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が2つであること" do
+      delete api_v1_quiz_bookmark_path(quiz_bookmark.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_branches_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_branches_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe "Api::V1::QuizBranches", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_branches_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -56,6 +62,12 @@ RSpec.describe "Api::V1::QuizBranches", type: :request do
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_branches_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
   end
 
@@ -68,8 +80,11 @@ RSpec.describe "Api::V1::QuizBranches", type: :request do
     let!(:not_related_commit_message) { create(:quiz_commit_message, quiz_branch: branch2) }
 
     context "引数がquiz_branchのidの場合" do
-      it "quiz_branchに紐づいたデータのみを取得すること" do
+      before do
         get api_v1_quiz_branch_path(branch.id)
+      end
+
+      it "quiz_branchに紐づいたデータのみを取得すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -90,6 +105,11 @@ RSpec.describe "Api::V1::QuizBranches", type: :request do
         expect(res["data_messages"].length).to eq 5
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 5
+      end
     end
   end
 
@@ -103,12 +123,20 @@ RSpec.describe "Api::V1::QuizBranches", type: :request do
       }
     end
 
-    it "quiz_branchデータの更新が成功すること" do
+    before do
       patch api_v1_quiz_branch_path(branch.id), params: update
+    end
+
+    it "quiz_branchデータの更新が成功すること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["data"]["quiz_branch_name"]).to eq(branch2.quiz_branch_name)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が2つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
     end
   end
 
@@ -120,6 +148,12 @@ RSpec.describe "Api::V1::QuizBranches", type: :request do
       expect(res["message"]).to eq("Deleted the post")
       expect(res["data"]["id"]).to eq(branch.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_branch_path(branch.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_comment_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_comment_spec.rb
@@ -16,8 +16,11 @@ RSpec.describe "Api::V1::QuizComments", type: :request do
   end
 
   describe "GET /index" do
-    it "全てのquizデータを取得できていること" do
+    before do
       get api_v1_quiz_comments_path
+    end
+
+    it "全てのquizデータを取得できていること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["message"]).to eq("Loaded quiz comments")
@@ -26,6 +29,11 @@ RSpec.describe "Api::V1::QuizComments", type: :request do
       expect(QuizComment.count).to eq 2
       expect(res["data"].count).to eq 2
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 
@@ -39,6 +47,12 @@ RSpec.describe "Api::V1::QuizComments", type: :request do
       expect(res["data"]["comment"]).to eq("作成確認用")
       expect(response).to have_http_status(:success)
     end
+
+    it "取得するdataの要素が2つであること" do
+      post api_v1_quiz_comments_path, params: param
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+    end
   end
 
   describe "delete /destroy" do
@@ -49,6 +63,12 @@ RSpec.describe "Api::V1::QuizComments", type: :request do
       expect(res["message"]).to eq("Deleted the quiz comment")
       expect(res["data"]["id"]).to eq(quiz_comment.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_comment_path(quiz_comment.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_commit_messages_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_commit_messages_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe "Api::V1::QuizCommitMessages", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_commit_messages_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -54,6 +60,12 @@ RSpec.describe "Api::V1::QuizCommitMessages", type: :request do
         expect(res["data"][1]["quiz_commit_message"]).to eq("複数作成確認用2")
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_commit_messages_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
       end
     end
   end
@@ -92,8 +104,11 @@ RSpec.describe "Api::V1::QuizCommitMessages", type: :request do
     end
 
     context "引数がquiz_commit_messageのidの場合" do
-      it "quiz_commit_messageに紐づいたデータのみを取得すること" do
+      before do
         get api_v1_quiz_commit_message_path(commit_message.id)
+      end
+
+      it "quiz_commit_messageに紐づいたデータのみを取得すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -109,6 +124,11 @@ RSpec.describe "Api::V1::QuizCommitMessages", type: :request do
         expect(res["data_history_of_committed_files"].length).to eq 5
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が4つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 4
+      end
     end
   end
 
@@ -122,6 +142,12 @@ RSpec.describe "Api::V1::QuizCommitMessages", type: :request do
       expect(res["message"]).to eq("Deleted the post")
       expect(res["data"]["id"]).to eq(commit_message.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_commit_message_path(commit_message.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_first_or_lasts_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_first_or_lasts_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_first_or_lasts_path, params: param
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内の情報が2つの場合" do
@@ -55,6 +61,12 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+    end
+
+    it "取得するdataの要素が2つであること" do
+      post api_v1_quiz_first_or_lasts_path, params: mulch_params
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
     end
   end
 
@@ -73,8 +85,11 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
     end
 
     context "引数がquiz_first_or_lastのidの場合" do
-      it "quiz_first_or_lastに紐づいたデータのみを取得すること" do
+      before do
         get api_v1_quiz_first_or_last_path(first_or_last.id)
+      end
+
+      it "quiz_first_or_lastに紐づいたデータのみを取得すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -90,6 +105,11 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
         expect(res["data_remote_branches"].length).to eq 5
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が4つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 4
+      end
     end
   end
 
@@ -103,6 +123,12 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
       expect(res["message"]).to eq("Deleted the post")
       expect(res["data"]["id"]).to eq(first_or_last.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_first_or_last_path(first_or_last.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_history_of_committed_files_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_history_of_committed_files_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe "Api::V1::QuizHistoryOfCommittedFiles", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_history_of_committed_files_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -71,6 +77,12 @@ RSpec.describe "Api::V1::QuizHistoryOfCommittedFiles", type: :request do
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_history_of_committed_files_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
   end
 
@@ -82,7 +94,14 @@ RSpec.describe "Api::V1::QuizHistoryOfCommittedFiles", type: :request do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["message"]).to include("Deleted the post")
+      expect(res["data"]["id"]).to eq(history_file.id)
       expect(response).to have_http_status(200)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_history_of_committed_file_path(history_file.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_index_files_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_index_files_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "QuizIndexFiles", type: :request do
   let(:branch) { create(:quiz_branch) }
-  let(:index_file) { create(:quiz_index_file) }
-  let(:index_file2) { create(:quiz_index_file, quiz_index_file_text_status: "こんにちは") }
+  let!(:index_file) { create(:quiz_index_file) }
+  let!(:index_file2) { create(:quiz_index_file, quiz_index_file_text_status: "こんにちは") }
 
   describe "GET /create" do
     let(:params) do
@@ -36,23 +36,39 @@ RSpec.describe "QuizIndexFiles", type: :request do
 
     context "送られてきた配列内のファイル情報が一つの場合" do
       it "データ登録が成功すること" do
-        post api_v1_quiz_index_files_path, params: params
+        expect do
+          post api_v1_quiz_index_files_path, params: params
+        end.to change(QuizIndexFile, :count).by(+1)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["data"][0]["quiz_index_file_name"]).to eq("ファイル名")
         expect(res["data"][0]["quiz_index_file_text_status"]).to eq("こんにちは")
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_index_files_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
       it "データ登録が成功すること" do
-        post api_v1_quiz_index_files_path, params: mulch_params
+        expect do
+          post api_v1_quiz_index_files_path, params: mulch_params
+        end.to change(QuizIndexFile, :count).by(+2)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["data"][0]["quiz_index_file_name"]).to eq("ファイル名")
         expect(res["data"][1]["quiz_index_file_name"]).to eq("ファイル名2")
         expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_index_files_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
       end
     end
   end
@@ -68,23 +84,40 @@ RSpec.describe "QuizIndexFiles", type: :request do
       }
     end
 
-    it "データ更新が成功すること" do
+    before do
       patch api_v1_quiz_index_file_path(index_file.id), params: update
+    end
+
+    it "データ更新が成功すること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["data"]["quiz_index_file_name"]).to eq(index_file2.quiz_index_file_name)
       expect(res["data"]["quiz_index_file_text_status"]).to eq(index_file2.quiz_index_file_text_status)
       expect(response).to have_http_status(:success)
     end
+
+    it "取得するdataの要素が2つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+    end
   end
 
   describe "GET /destroy" do
     it "データ削除が成功すること" do
-      delete api_v1_quiz_index_file_path(index_file.id)
+      expect do
+        delete api_v1_quiz_index_file_path(index_file.id)
+      end.to change(QuizIndexFile, :count).by(-1)
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["message"]).to include("Deleted the post")
+      expect(res["data"]["id"]).to eq(index_file.id)
       expect(response).to have_http_status(200)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_index_file_path(index_file.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_remote_branches_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_remote_branches_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe "Api::V1::QuizRemoteBranches", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_remote_branches_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -56,6 +62,12 @@ RSpec.describe "Api::V1::QuizRemoteBranches", type: :request do
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_remote_branches_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
   end
 
@@ -68,8 +80,11 @@ RSpec.describe "Api::V1::QuizRemoteBranches", type: :request do
     end
 
     context "引数がquiz_remote_branchのidの場合" do
-      it "quiz_remote_branchに紐づいたデータのみを取得すること" do
+      before do
         get api_v1_quiz_remote_branch_path(remote_branch.id)
+      end
+
+      it "quiz_remote_branchに紐づいたデータのみを取得すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -79,6 +94,11 @@ RSpec.describe "Api::V1::QuizRemoteBranches", type: :request do
         end
         expect(res["data_remote_messages"].length).to eq 5
         expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が3つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
       end
     end
   end
@@ -93,6 +113,12 @@ RSpec.describe "Api::V1::QuizRemoteBranches", type: :request do
       expect(res["message"]).to eq("Deleted the post")
       expect(res["data"]["id"]).to eq(remote_branch.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_remote_branch_path(remote_branch.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_remote_commit_messages_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_remote_commit_messages_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe "Api::V1::QuizRemoteCommitMessages", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_remote_commit_messages_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -55,6 +61,12 @@ RSpec.describe "Api::V1::QuizRemoteCommitMessages", type: :request do
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+    end
+
+    it "取得するdataの要素が2つであること" do
+      post api_v1_quiz_remote_commit_messages_path, params: mulch_params
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
     end
   end
 
@@ -77,8 +89,11 @@ RSpec.describe "Api::V1::QuizRemoteCommitMessages", type: :request do
     end
 
     context "引数がquiz_remote_commit_messageのidの場合" do
-      it "quiz_remote_commit_messageに紐づいたデータのみを取得すること" do
+      before do
         get api_v1_quiz_remote_commit_message_path(remote_commit_message.id)
+      end
+
+      it "quiz_remote_commit_messageに紐づいたデータのみを取得すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -88,6 +103,11 @@ RSpec.describe "Api::V1::QuizRemoteCommitMessages", type: :request do
         end
         expect(res["data_remote_repository_files"].length).to eq 5
         expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が3つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
       end
     end
   end
@@ -102,6 +122,12 @@ RSpec.describe "Api::V1::QuizRemoteCommitMessages", type: :request do
       expect(res["message"]).to eq("Deleted the post")
       expect(res["data"]["id"]).to eq(remote_commit_message.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_remote_commit_message_path(remote_commit_message.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_remote_repository_files_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_remote_repository_files_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe "Api::V1::QuizRemoteRepositoryFiles", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_remote_repository_files_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -66,6 +72,12 @@ RSpec.describe "Api::V1::QuizRemoteRepositoryFiles", type: :request do
         expect(response).to have_http_status(:success)
       end
     end
+
+    it "取得するdataの要素が2つであること" do
+      post api_v1_quiz_remote_repository_files_path, params: mulch_params
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+    end
   end
 
   describe "delete /destroy" do
@@ -79,5 +91,11 @@ RSpec.describe "Api::V1::QuizRemoteRepositoryFiles", type: :request do
       expect(res["data"]["id"]).to eq(remote_repository_file.id)
       expect(response).to have_http_status(:success)
     end
+  end
+
+  it "取得するdataの要素が3つであること" do
+    delete api_v1_quiz_remote_repository_file_path(remote_repository_file.id)
+    res = JSON.parse(response.body)
+    expect(res.length).to eq 3
   end
 end

--- a/backend/spec/requests/api/v1/quiz_repository_files_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_repository_files_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe "Api::V1::QuizRepositoryFiles", type: :request do
         expect(res["data"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_repository_files_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
@@ -65,6 +71,12 @@ RSpec.describe "Api::V1::QuizRepositoryFiles", type: :request do
         expect(res["data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_repository_files_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
   end
 
@@ -78,6 +90,12 @@ RSpec.describe "Api::V1::QuizRepositoryFiles", type: :request do
       expect(res["message"]).to eq("Deleted the post")
       expect(res["data"]["id"]).to eq(repository_file.id)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_repository_file_path(repository_file.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quiz_tags_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_tags_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::QuizTags", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/api/v1/quiz_tags/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/api/v1/quiz_tags/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/backend/spec/requests/api/v1/quiz_tags_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_tags_spec.rb
@@ -1,18 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::QuizTags", type: :request do
+  let!(:quiz) { create(:quiz) }
+  let!(:quiz_tag) { create(:quiz_tag) }
+  let(:param) do
+    {
+      quiz_tag: {
+        quiz_id: quiz.id,
+        tag: "作成確認用",
+      },
+    }
+  end
+
   describe "GET /create" do
-    it "returns http success" do
-      get "/api/v1/quiz_tags/create"
+    it "データ登録が成功すること" do
+      expect { post api_v1_quiz_tags_path, params: param }.to change(QuizTag, :count).by(+1)
+      res = JSON.parse(response.body)
+      expect(res["status"]).to eq("SUCCESS")
+      expect(res["data"]["quiz_id"]).to eq(quiz.id)
+      expect(res["data"]["tag"]).to eq("作成確認用")
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      post api_v1_quiz_tags_path, params: param
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
     end
   end
 
   describe "GET /destroy" do
-    it "returns http success" do
-      get "/api/v1/quiz_tags/destroy"
+    it "quiz_tagデータの削除が成功すること" do
+      expect { delete api_v1_quiz_tag_path(quiz_tag.id) }.to change(QuizTag, :count).by(-1)
+      res = JSON.parse(response.body)
+      expect(res["status"]).to eq("SUCCESS")
+      expect(res["message"]).to eq("Deleted the quiz tag")
+      expect(res["data"]["id"]).to eq(quiz_tag.id)
       expect(response).to have_http_status(:success)
     end
-  end
 
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_tag_path(quiz_tag.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/quiz_worktree_files_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_worktree_files_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "Api::V1::QuizWorktreeFiles", type: :request do
   let(:branch) { create(:quiz_branch) }
-  let(:worktree_file) { create(:quiz_worktree_file) }
-  let(:worktree_file2) { create(:quiz_worktree_file, quiz_worktree_file_text_status: "こんにちは") }
+  let!(:worktree_file) { create(:quiz_worktree_file) }
+  let!(:worktree_file2) { create(:quiz_worktree_file, quiz_worktree_file_text_status: "こんにちは") }
 
   describe "GET /create" do
     let(:params) do
@@ -36,23 +36,39 @@ RSpec.describe "Api::V1::QuizWorktreeFiles", type: :request do
 
     context "送られてきた配列内のファイル情報が一つの場合" do
       it "データ登録が成功すること" do
-        post api_v1_quiz_worktree_files_path, params: params
+        expect do
+          post api_v1_quiz_worktree_files_path, params: params
+        end.to change(QuizWorktreeFile, :count).by(+1)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["data"][0]["quiz_worktree_file_name"]).to eq("ファイル名")
         expect(res["data"][0]["quiz_worktree_file_text_status"]).to eq("こんにちは")
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_worktree_files_path, params: params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
+      end
     end
 
     context "送られてきた配列内のファイル情報が複数の場合" do
       it "データ登録が成功すること" do
-        post api_v1_quiz_worktree_files_path, params: mulch_params
+        expect do
+          post api_v1_quiz_worktree_files_path, params: mulch_params
+        end.to change(QuizWorktreeFile, :count).by(+2)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["data"][0]["quiz_worktree_file_name"]).to eq("ファイル名")
         expect(res["data"][1]["quiz_worktree_file_name"]).to eq("ファイル名2")
         expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が2つであること" do
+        post api_v1_quiz_worktree_files_path, params: mulch_params
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 2
       end
     end
   end
@@ -68,23 +84,38 @@ RSpec.describe "Api::V1::QuizWorktreeFiles", type: :request do
       }
     end
 
-    it "データ更新が成功すること" do
+    before do
       patch api_v1_quiz_worktree_file_path(worktree_file.id), params: update
+    end
+
+    it "データ更新が成功すること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["data"]["quiz_worktree_file_name"]).to eq(worktree_file2.quiz_worktree_file_name)
       expect(res["data"]["quiz_worktree_file_text_status"]).to eq(worktree_file2.quiz_worktree_file_text_status)
       expect(response).to have_http_status(:success)
     end
+
+    it "取得するdataの要素が2つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+    end
   end
 
   describe "GET /destroy" do
     it "データ削除が成功すること" do
-      delete api_v1_quiz_worktree_file_path(worktree_file.id)
+      expect { delete api_v1_quiz_worktree_file_path(worktree_file.id) }.to change(QuizWorktreeFile, :count).by(-1)
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["message"]).to include("Deleted the post")
+      expect(res["data"]["id"]).to eq(worktree_file.id)
       expect(response).to have_http_status(200)
+    end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_worktree_file_path(worktree_file.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 end

--- a/backend/spec/requests/api/v1/quizzes_spec.rb
+++ b/backend/spec/requests/api/v1/quizzes_spec.rb
@@ -30,8 +30,11 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
   end
 
   describe "GET /index" do
-    it "全てのquizデータを取得できていること" do
+    before do
       get api_v1_quizzes_path
+    end
+
+    it "全てのquizデータを取得できていること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["message"]).to eq("Loaded quizzes")
@@ -40,6 +43,11 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
       expect(Quiz.count).to eq 2
       expect(res["data"].count).to eq 2
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が2つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
     end
   end
 
@@ -53,12 +61,21 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
       expect(res["data"]["quiz_type"]).to eq("user")
       expect(response).to have_http_status(:success)
     end
+
+    it "取得するdataの要素が2つであること" do
+      post api_v1_quizzes_path, params: param
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+    end
   end
 
   describe "GET /show" do
     context "引数がquizのidの場合" do
-      it "quizに紐づいたquiz_first_or_lastsのデータのみを取得すること" do
+      before do
         get api_v1_quiz_path(quiz.id)
+      end
+
+      it "quizに紐づいたquiz_first_or_lastsのデータのみを取得すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
@@ -71,17 +88,30 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
         expect(res["quiz_first_or_lasts_data"].length).to eq 2
         expect(response).to have_http_status(:success)
       end
+
+      it "取得するdataの要素が4つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 4
+      end
     end
   end
 
   describe "PATCH /update" do
-    it "quizデータの更新が成功すること" do
+    before do
       patch api_v1_quiz_path(quiz.id), params: update
+    end
+
+    it "quizデータの更新が成功すること" do
       res = JSON.parse(response.body)
       expect(res["status"]).to eq("SUCCESS")
       expect(res["data"]["quiz_title"]).to eq(quiz2.quiz_title)
       expect(res["data"]["quiz_introduction"]).to eq(quiz2.quiz_introduction)
       expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が2つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
     end
   end
 
@@ -94,20 +124,34 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
       expect(res["data"]["id"]).to eq(quiz.id)
       expect(response).to have_http_status(:success)
     end
+
+    it "取得するdataの要素が3つであること" do
+      delete api_v1_quiz_path(quiz.id)
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+    end
   end
 
   describe "GET /tag" do
     let!(:quiz_tag) { create(:quiz_tag, quiz: quiz) }
 
+    before do
+      get tag_api_v1_quiz_path(quiz.id)
+    end
+
     context "引数がquizのidの場合" do
       it "quizに紐づいたquiz_tagのデータのみを取得すること" do
-        get tag_api_v1_quiz_path(quiz.id)
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quiz tags")
         expect(res["quiz_tags_data"][0]["id"]).to eq(quiz_tag.id)
         expect(res["quiz_tags_data"].length).to eq 1
         expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が3つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
       end
     end
   end

--- a/backend/spec/requests/api/v1/quizzes_spec.rb
+++ b/backend/spec/requests/api/v1/quizzes_spec.rb
@@ -95,4 +95,20 @@ RSpec.describe "Api::V1::Quizzes", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "GET /tag" do
+    let!(:quiz_tag) { create(:quiz_tag, quiz: quiz) }
+
+    context "引数がquizのidの場合" do
+      it "quizに紐づいたquiz_tagのデータのみを取得すること" do
+        get tag_api_v1_quiz_path(quiz.id)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["message"]).to eq("Loaded quiz tags")
+        expect(res["quiz_tags_data"][0]["id"]).to eq(quiz_tag.id)
+        expect(res["quiz_tags_data"].length).to eq 1
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
 end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -24,44 +24,44 @@ RSpec.describe "Api::V1::Users", type: :request do
         get api_v1_user_path(user.id)
       end
 
-      it "userの関連しているquizデータのみを取得できること" do
+      it "通信が成功すること" do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
+        expect(response).to have_http_status(:success)
+      end
+
+      it "userの関連しているquizデータのみを取得できること" do
+        res = JSON.parse(response.body)
         expect(res["data"][0]["id"]).to eq(user_quiz1.id)
         expect(res["data"][1]["id"]).to eq(user_quiz2.id)
         expect(res["data"][0]["id"]).not_to eq(user2_quiz1.id)
         expect(res["data"][1]["id"]).not_to eq(user2_quiz2.id)
         expect(res["data"].length).to eq 2
-        expect(response).to have_http_status(:success)
       end
 
       it "userの関連しているquiz_answer_recordデータのみを取得できること" do
         res = JSON.parse(response.body)
-        expect(res["status"]).to eq("SUCCESS")
-        expect(res["message"]).to eq("Loaded quizzes")
         expect(res["data_answer_records"][0]["id"]).to eq(related_quiz_answer_record.id)
         expect(res["data_answer_records"].length).to eq 1
-        expect(response).to have_http_status(:success)
       end
 
       it "userが作成したquizデータに関連しているcommentのみを取得できること" do
         res = JSON.parse(response.body)
-        expect(res["status"]).to eq("SUCCESS")
-        expect(res["message"]).to eq("Loaded quizzes")
         expect(res["data_comments"][0]["id"]).to eq(related_quiz_comment.id)
         expect(res["data_comments"][1]["id"]).to eq(related_quiz_comment2.id)
         expect(res["data_comments"].length).to eq 2
-        expect(response).to have_http_status(:success)
       end
 
-      it "userが作成したquizデータに関連しているcommentのみを取得できること" do
+      it "userが作成したquizデータに関連しているtagのみを取得できること" do
         res = JSON.parse(response.body)
-        expect(res["status"]).to eq("SUCCESS")
-        expect(res["message"]).to eq("Loaded quizzes")
         expect(res["data_tags"][0]["id"]).to eq(related_quiz_tag.id)
         expect(res["data_tags"].length).to eq 1
-        expect(response).to have_http_status(:success)
+      end
+
+      it "取得するdataの要素が6つであること" do
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 6
       end
     end
   end
@@ -84,6 +84,12 @@ RSpec.describe "Api::V1::Users", type: :request do
       expect(res["data"]["user_self_introduction"]).to eq(user2.user_self_introduction)
       expect(res["data"]["image"]["url"].split("/").last).to eq(user2.image.url.split("/").last)
       expect(response).to have_http_status(200)
+    end
+
+    it "取得するdataの要素が2つであること" do
+      put api_v1_user_path(user.id), params: params
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
     end
   end
 end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -13,8 +13,11 @@ RSpec.describe "Api::V1::Users", type: :request do
   let!(:not_related_quiz_answer_record) { create(:quiz_answer_record) }
 
   describe "GET /api/v1/users#show" do
-    let!(:quiz_comment) { create(:quiz_comment, quiz: user_quiz1) }
-    let!(:quiz_comment2) { create(:quiz_comment, quiz: user_quiz1, user: user2) }
+    let!(:related_quiz_comment) { create(:quiz_comment, quiz: user_quiz1) }
+    let!(:related_quiz_comment2) { create(:quiz_comment, quiz: user_quiz1, user: user2) }
+    let!(:not_related_quiz_comment) { create(:quiz_comment, quiz: user2_quiz1, user: user2) }
+    let!(:related_quiz_tag) { create(:quiz_tag, quiz: user_quiz1) }
+    let!(:not_related_quiz_tag) { create(:quiz_comment, quiz: user2_quiz1) }
 
     context "引数がquizのidの場合" do
       before do
@@ -46,9 +49,18 @@ RSpec.describe "Api::V1::Users", type: :request do
         res = JSON.parse(response.body)
         expect(res["status"]).to eq("SUCCESS")
         expect(res["message"]).to eq("Loaded quizzes")
-        expect(res["data_comments"][0]["id"]).to eq(quiz_comment.id)
-        expect(res["data_comments"][1]["id"]).to eq(quiz_comment2.id)
+        expect(res["data_comments"][0]["id"]).to eq(related_quiz_comment.id)
+        expect(res["data_comments"][1]["id"]).to eq(related_quiz_comment2.id)
         expect(res["data_comments"].length).to eq 2
+        expect(response).to have_http_status(:success)
+      end
+
+      it "userが作成したquizデータに関連しているcommentのみを取得できること" do
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq("SUCCESS")
+        expect(res["message"]).to eq("Loaded quizzes")
+        expect(res["data_tags"][0]["id"]).to eq(related_quiz_tag.id)
+        expect(res["data_tags"].length).to eq 1
         expect(response).to have_http_status(:success)
       end
     end

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -15,6 +15,7 @@ import CreateQuiz from "components/pages/CreateQuiz"
 import { getCurrentUser } from "lib/api/auth"
 import { User } from "interfaces/index"
 import QuizList from "components/pages/QuizList"
+import QuizSetUp from "components/pages/QuizSetUp"
 
 export const AuthContext = createContext({} as {
   loading: boolean
@@ -84,6 +85,7 @@ const App: React.FC = () => {
                 <Route exact path="/user/bookmark/list" component={QuizList} />
                 <Route exact path="/quiz/list" component={QuizList} />
                 <Route exact path="/quiz" component={CreateQuiz} />
+                <Route path="/quiz/setup/:id" component={QuizSetUp} />
                 <Route path="/quiz/edit/:id" component={CreateQuiz} />
                 <Route path="/quiz/init/edit/:id" component={CreateQuiz} />
                 <Route path="/quiz/answer/:id" component={CreateQuiz} />

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -271,7 +271,7 @@ const CreateOrUpdateQuizButton: React.FC = () => {
       console.log(quizRemoteRepositoryFileRes)
       console.log("create quiz success!!")
 
-      history.push("/")
+      {location.pathname === "/quiz" && history.push(`/quiz/setup/${aboutQuizRes?.data.data.id}`)}
 
     } catch (err) {
       console.log(err)
@@ -524,6 +524,9 @@ const CreateOrUpdateQuizButton: React.FC = () => {
       console.log("既存ブランチからRepositoryFile新規作成",quizRepositoryFileRes)
       console.log("既存ブランチからRemoteCommitMessage新規作成",QuizRemoteCommitMessageRes)
       console.log("既存ブランチからRemoteRepositoryFile新規作成",quizRemoteRepositoryFileRes)
+
+      history.push(`/quiz/setup/${id}`)
+
     } catch (err) {
       console.log(err)
     }

--- a/frontend/app/src/components/pages/QuizSetUp.tsx
+++ b/frontend/app/src/components/pages/QuizSetUp.tsx
@@ -1,13 +1,61 @@
-import { useParams } from "react-router-dom"
+import { Button, makeStyles, Theme } from "@material-ui/core"
+import { Link, useParams } from "react-router-dom"
 import QuizTag from "./QuizTag"
 
+const useStyles = makeStyles((theme: Theme) => ({
+  submitBtn: {
+    marginTop: theme.spacing(2),
+    flexGrow: 1,
+    textTransform: "none",
+    backgroundColor: "#f5f5f5"
+  }
+}))
+
 const QuizSetUp: React.FC = () => {
+  const classes = useStyles()
   const { id } = useParams<{ id: string }>()
 
   return(
-    <QuizTag
-      quizId={Number(id)}
-      />
+    <>
+      <QuizTag
+        quizId={Number(id)}
+        />
+      <Button
+        type="submit"
+        variant="contained"
+        size="large"
+        fullWidth
+        color="default"
+        className={classes.submitBtn}
+        component={Link}
+        to={`/quiz/edit/${id}`}
+      >
+        もう一度編集する
+      </Button>
+      <Button
+        type="submit"
+        variant="contained"
+        size="large"
+        fullWidth
+        color="default"
+        className={classes.submitBtn}
+        component={Link}
+        to={`/quiz/init/edit/${id}`}
+      >
+        初期値を編集
+      </Button>
+      <Button
+        variant="contained"
+        fullWidth
+        size="large"
+        color="default"
+        className={classes.submitBtn}
+        component={Link}
+        to="/"
+        >
+        Home
+        </Button>
+    </>
   )
 }
 

--- a/frontend/app/src/components/pages/QuizSetUp.tsx
+++ b/frontend/app/src/components/pages/QuizSetUp.tsx
@@ -1,0 +1,14 @@
+import { useParams } from "react-router-dom"
+import QuizTag from "./QuizTag"
+
+const QuizSetUp: React.FC = () => {
+  const { id } = useParams<{ id: string }>()
+
+  return(
+    <QuizTag
+      quizId={Number(id)}
+      />
+  )
+}
+
+export default QuizSetUp

--- a/frontend/app/src/components/pages/QuizTag.tsx
+++ b/frontend/app/src/components/pages/QuizTag.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { Checkbox, FormControlLabel } from '@material-ui/core';
+import { getQuizTags } from 'lib/api/quizzes';
+import { createQuizTag, deleteQuizTag } from 'lib/api/quiz_tags';
+
+const QuizTag: React.FC<{ quizId: number }> = ({quizId}) => {
+
+  const [commandTag, setCommandTag] = useState([{
+    id: "",
+    commandTag : ""
+  }])
+
+  const tagList = [
+    "add" ,
+    "commit",
+    "commit --amend",
+    "push",
+    "push -d",
+    "branch",
+    "branch -d",
+    "branch -D",
+    "branch -m",
+    "checkout",
+    "checkout -b",
+    "touch",
+    "rm",
+    "rm --cashed",
+    "reset",
+    "reset --soft",
+    "reset --mixed",
+    "reset --hard"
+  ];
+
+  const handleAddTags = async(commandName :any) => {
+    const TagRes = await createQuizTag({
+      quizId: quizId,
+      tag: commandName
+    })
+    setCommandTag(commandTag => [...commandTag,{
+      id: TagRes.data.data.id,
+      commandTag: TagRes.data.data.tag
+    }])
+    console.log(TagRes)
+  }
+
+  const handleRemoveTags = (commandName :any) => {
+    setCommandTag(
+      commandTag.filter(command =>
+        command.commandTag !== commandName
+        ))
+    const deleteQuizTagData = Number(commandTag.filter(tag => tag.commandTag === commandName)[0].id)
+    const deleteTagRes = deleteQuizTagData && deleteQuizTag(deleteQuizTagData)
+    console.log(deleteTagRes)
+  }
+
+  const handleGetQuizTags = async() => {
+    const QuizRes = await getQuizTags(quizId)
+    console.log(QuizRes)
+    QuizRes.data.quizTagsData.forEach((tag :any) =>
+    setCommandTag(commandTag => [...commandTag,{
+      id: tag.id,
+      commandTag: tag.tag
+    }]))
+  }
+
+  const checkTagExist = (tagName :string) => commandTag.some(aa => aa.commandTag === tagName)
+
+  useEffect(() => {
+    console.log("commandTag", commandTag)
+  },[commandTag])
+
+  useEffect(() => {
+    location.pathname === `/quiz/setup/${quizId}` && handleGetQuizTags()
+  },[])
+
+  return (
+    <>
+      <p>{commandTag.map(commandTag => commandTag.commandTag)}</p>
+      {tagList.map(tag =>
+        <FormControlLabel
+          control={
+            <Checkbox
+                checked={checkTagExist(tag)}
+                onClick={e => {
+                  checkTagExist(tag)
+                  ? handleRemoveTags(tag)
+                  : handleAddTags(tag)
+                }}
+                />
+            }
+          label={tag}
+        />
+      )}
+    </>
+  );
+}
+
+export default QuizTag

--- a/frontend/app/src/interfaces/index.ts
+++ b/frontend/app/src/interfaces/index.ts
@@ -151,3 +151,8 @@ export interface createQuizCommentData {
   quizId: number
   comment: string
 }
+
+export interface createQuizTagData {
+  quizId: number
+  tag: string
+}

--- a/frontend/app/src/lib/api/quiz_tags.ts
+++ b/frontend/app/src/lib/api/quiz_tags.ts
@@ -1,0 +1,10 @@
+import { createQuizTagData } from "interfaces"
+import client from "lib/api/client"
+
+export const createQuizTag = (data: createQuizTagData) => {
+  return client.post("quiz_tags", data)
+}
+
+export const deleteQuizTag = (id: number | undefined | null) => {
+  return client.delete(`quiz_tags/${id}`)
+}

--- a/frontend/app/src/lib/api/quizzes.ts
+++ b/frontend/app/src/lib/api/quizzes.ts
@@ -22,3 +22,7 @@ export const getQuiz = (id: number | undefined | null) => {
 export const deleteQuiz = (id: number | undefined | null) => {
   return client.delete(`quizzes/${id}`)
 }
+
+export const getQuizTags = (id: number | undefined | null) => {
+  return client.get(`quizzes/${id}/tag`)
+}


### PR DESCRIPTION
 概要
--
close #19 

行ったこと
--
■backend
【タグ機能用のテーブル/controller/model/テストを作成】
Validationでtagカラムが空の場合は保存が失敗するテストを追加

【quiz_controllerに関連しているタグデータのみを取得するアクションを追加】
クイズに関連しているタグデータをshowアクションで取得してしまうと、不要なデータまで取得してしまうため、
タグデータのみを取得するアクションを作成。
別のcontrollerファイルでも同じように必要以上にshowアクションでデータを取得している場面がおそらくいくつかあるため、確認し別のブランチで新しいアクションを作成する。

【request_specの各ファイルのアクションごとにjson_dataの数をテストする項目を追加】
途中からアクションの中身を変更(jsonでフロントに返すdataの要素を追加/削除等)することが増えている。
そのためdata数をテストすれば「アクションの中身を修正したがテストの修正はしていない」という状態になることを防ぐことができると考え、テスト項目に追加した。

■frontend
【クイズごとにタグ付けを行うページを作成】
タグ付けを行えるページを作成し、クイズが作成/更新成功後に自動的に移動するように記述を追加。
タグ付けだけでなく、クイズの初期値の値を編集/もう一度クイズの解答を編集するページに移動できるボタンを設置している。

【タグ機能】
タグ付けできる項目は、事前に運営が用意する。
チェックボックスにチェックをつけた時点で指定されたタグ名のデータが作成され、チェックを外した場合はデータが削除される。

行わなかったこと・理由
--
【検索機能の実装】
タグの検索機能は、次のブランチで"ユーザー名/クイズ名/タグ"ごとにキーワード検索ができる機能を実装する予定。
そのため現ブランチでは実装していない。