### PR TITLE
検索機能の実装

### DIFF
--- a/backend/app/controllers/api/v1/quiz_tags_controller.rb
+++ b/backend/app/controllers/api/v1/quiz_tags_controller.rb
@@ -2,6 +2,15 @@ class Api::V1::QuizTagsController < ApplicationController
   before_action :quiz_tag_params, only: [:create]
   before_action :set_quiz_tag, only: [:destroy]
 
+  def index
+    quiz_tags = QuizTag.preload(:quiz)
+    render json: {
+      status: 'SUCCESS',
+      message: 'Loaded quiz tags',
+      data: quiz_tags,
+    }
+  end
+
   def create
     quiz_tags = QuizTag.new(quiz_tag_params)
     if quiz_tags.save

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       resources :quiz_answer_records, only: %i[create]
       resources :quiz_bookmarks, only: %i[index create destroy]
       resources :quiz_comments, only: %i[index create destroy]
-      resources :quiz_tags, only: %i[create destroy]
+      resources :quiz_tags, only: %i[index create destroy]
       resources :quiz_first_or_lasts, only: %i[create show destroy]
       resources :quiz_branches, only: %i[create show update destroy]
       resources :quiz_remote_branches, only: %i[create show destroy]

--- a/backend/spec/requests/api/v1/quiz_tags_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_tags_spec.rb
@@ -12,6 +12,30 @@ RSpec.describe "Api::V1::QuizTags", type: :request do
     }
   end
 
+  describe "GET /index" do
+    let!(:quiz_tag2) { create(:quiz_tag) }
+
+    before do
+      get api_v1_quiz_tags_path
+    end
+
+    it "全てのquizデータを取得できていること" do
+      res = JSON.parse(response.body)
+      expect(res["status"]).to eq("SUCCESS")
+      expect(res["message"]).to eq("Loaded quiz tags")
+      expect(res["data"][0]["id"]).to eq(quiz_tag.id)
+      expect(res["data"][1]["id"]).to eq(quiz_tag2.id)
+      expect(QuizTag.count).to eq 2
+      expect(res["data"].count).to eq 2
+      expect(response).to have_http_status(:success)
+    end
+
+    it "取得するdataの要素が2つであること" do
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+    end
+  end
+
   describe "GET /create" do
     it "データ登録が成功すること" do
       expect { post api_v1_quiz_tags_path, params: param }.to change(QuizTag, :count).by(+1)

--- a/frontend/app/src/components/pages/QuizBookmarkOrderButton.tsx
+++ b/frontend/app/src/components/pages/QuizBookmarkOrderButton.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@material-ui/core";
+import { useContext } from "react"
+import { QuizBookmarkContext } from "./QuizList";
+
+const QuizBookmarkOrderButton :React.FC = () => {
+  const {
+    quizzes, setQuizzes,
+    quizBookmarks
+  } = useContext(QuizBookmarkContext)
+
+  const handleSortByNumberOfBookmarkssubmit = () => {
+    const bookmarksCount = (quizId :string) => quizBookmarks.filter(bookmark => bookmark.quizId === quizId).length
+    const newArrivalsOrderQuizzes = quizzes.sort((a, b) => ((bookmarksCount(a.id) > (bookmarksCount(b.id)) ? -1 : 1)))
+
+    setQuizzes(quizzes.filter(quiz => !quiz.id))
+    newArrivalsOrderQuizzes.map(newArrivalsOrderQuiz =>
+      setQuizzes(quizzes => [...quizzes,{
+        id: newArrivalsOrderQuiz.id,
+        quizTitle: newArrivalsOrderQuiz.quizTitle,
+        quizIntroduction: newArrivalsOrderQuiz.quizIntroduction,
+        createdAt: newArrivalsOrderQuiz.createdAt
+      }])
+    )
+  }
+
+  return(
+    <Button
+      type="submit"
+      variant="contained"
+      size="large"
+      color="default"
+      onClick={e => handleSortByNumberOfBookmarkssubmit()}
+      >
+      ブックマーク数順
+    </Button>
+  )
+}
+
+export default QuizBookmarkOrderButton

--- a/frontend/app/src/components/pages/QuizComment.tsx
+++ b/frontend/app/src/components/pages/QuizComment.tsx
@@ -92,7 +92,7 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
         Submit
       </Button>
       {deleteComment.map(comment =>
-        <p>
+        <p key={comment.id}>
           {comment.comment}
           <Button
             type="submit"

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -15,22 +15,26 @@ export const QuizBookmarkContext = createContext({} as {
   quizzes:{
     id: string,
     quizTitle: string,
-    quizIntroduction: string
+    quizIntroduction: string,
+    createdAt: string
   }[]
   setQuizzes: React.Dispatch<React.SetStateAction<{
     id: string,
     quizTitle: string,
-    quizIntroduction: string
+    quizIntroduction: string,
+    createdAt: string
   }[]>>
   quizzesForSearch:{
     id: string,
     quizTitle: string,
-    quizIntroduction: string
+    quizIntroduction: string,
+    createdAt: string
   }[]
   setQuizzesForSearch: React.Dispatch<React.SetStateAction<{
     id: string,
     quizTitle: string,
-    quizIntroduction: string
+    quizIntroduction: string,
+    createdAt: string
   }[]>>
   quizBookmarks: {
     id: string,
@@ -101,12 +105,14 @@ const QuizList: React.FC = () => {
   const [quizzes, setQuizzes] = useState([{
     id: "",
     quizTitle: "",
-    quizIntroduction: ""
+    quizIntroduction: "",
+    createdAt: ""
   }])
   const [quizzesForSearch, setQuizzesForSearch] = useState([{
     id: "",
     quizTitle: "",
-    quizIntroduction: ""
+    quizIntroduction: "",
+    createdAt: ""
   }])
   const [quizBookmarks, setQuizBookmarks] = useState([{
     id: "",

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -1,9 +1,9 @@
-import { Button, IconButton, InputBase, makeStyles, Paper, Theme } from "@material-ui/core";
-import SearchIcon from '@material-ui/icons/Search';
+import { Button, makeStyles, Theme } from "@material-ui/core";
 import { AuthContext } from "App";
 import { getAllQuizzes } from "lib/api/quizzes";
 import { getAllQuizBookmarks } from "lib/api/quiz_boolmarks";
 import { getAllQuizComments } from "lib/api/quiz_comments";
+import { getAllQuizTags } from "lib/api/quiz_tags";
 import { getUserQuizzes } from "lib/api/users"
 import React, { useContext, useState, useEffect, createContext } from "react";
 import { Link, useLocation } from "react-router-dom";
@@ -53,6 +53,16 @@ export const QuizBookmarkContext = createContext({} as {
     userId: number,
     quizId: number,
     comment: string
+  }[]>>
+  quizTags: {
+    id: number,
+    quizId: number,
+    tag: string
+  }[]
+  setQuizTags :React.Dispatch<React.SetStateAction<{
+    id: number,
+    quizId: number,
+    tag: string
   }[]>>
   quizComment: string
   setQuizComment :React.Dispatch<React.SetStateAction<string>>
@@ -109,6 +119,11 @@ const QuizList: React.FC = () => {
     quizId: 0,
     comment: ""
   }])
+  const [quizTags, setQuizTags] = useState([{
+    id: 0,
+    quizId: 0,
+    tag: ""
+  }])
   const [quizComment, setQuizComment] = useState("")
 
   const handleGetUserQuizzes = async () => {
@@ -121,6 +136,7 @@ const QuizList: React.FC = () => {
         setQuizzesForSearch(resUserQuizzes?.data.data)
         setQuizBookmarks(resAllBookmarks?.data.data)
         setQuizCommentHistory(resUserQuizzes?.data.dataComments)
+        setQuizTags(resUserQuizzes?.data.dataTags)
       } else {
         console.log("No likes")
       }
@@ -134,12 +150,14 @@ const QuizList: React.FC = () => {
       const resQuizzes = await getAllQuizzes()
       const resAllBookmarks = await getAllQuizBookmarks()
       const resQuizComments = await getAllQuizComments()
+      const resAllTags = await getAllQuizTags()
       console.log(resQuizzes)
       if (resQuizzes?.status === 200) {
         setQuizzes(resQuizzes?.data.data)
         setQuizzesForSearch(resQuizzes?.data.data)
         setQuizBookmarks(resAllBookmarks?.data.data)
         setQuizCommentHistory(resQuizComments?.data.data)
+        setQuizTags(resAllTags?.data.data)
       } else {
         console.log("No likes")
       }
@@ -165,10 +183,16 @@ const QuizList: React.FC = () => {
             bookmarkedQuizzes.some((allBookmark :any) =>
               allBookmark.id === res.quizId)
             )
+        const QuizTags =
+          resUserQuizzes?.data.dataTags.filter((res :any) =>
+            bookmarkedQuizzes.some((allBookmark :any) =>
+              allBookmark.id === res.quizId)
+            )
         setQuizzes(bookmarkedQuizzes)
         setQuizzesForSearch(bookmarkedQuizzes)
         setQuizBookmarks(resAllBookmarks?.data.data)
         setQuizCommentHistory(QuizComments)
+        setQuizTags(QuizTags)
       } else {
         console.log("No likes")
       }
@@ -207,6 +231,10 @@ const QuizList: React.FC = () => {
     console.log("quizCommentHistory", quizCommentHistory)
   }, [quizCommentHistory])
 
+  useEffect(() => {
+    console.log("quizTags", quizTags)
+  }, [quizTags])
+
   return (
     <>
     <QuizBookmarkContext.Provider
@@ -216,7 +244,8 @@ const QuizList: React.FC = () => {
         quizzesForSearch, setQuizzesForSearch,
         quizBookmarks, setQuizBookmarks,
         quizCommentHistory, setQuizCommentHistory,
-        quizComment, setQuizComment
+        quizComment, setQuizComment,
+        quizTags, setQuizTags
       }}>
       <QuizSearchForm />
       {quizzes.map((quiz) => (

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -70,8 +70,10 @@ export const QuizBookmarkContext = createContext({} as {
   }[]>>
   quizComment: string
   setQuizComment :React.Dispatch<React.SetStateAction<string>>
-  text: string
-  setText :React.Dispatch<React.SetStateAction<string>>
+  searchQuiztitle: string
+  setSearchQuiztitle :React.Dispatch<React.SetStateAction<string>>
+  searchQuizIntroduction: string
+  setSearchQuizIntroduction :React.Dispatch<React.SetStateAction<string>>
 })
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -101,7 +103,8 @@ const QuizList: React.FC = () => {
   const location = useLocation()
 
   const { currentUser } = useContext(AuthContext)
-  const [text, setText] = useState("")
+  const [searchQuiztitle, setSearchQuiztitle] = useState("")
+  const [searchQuizIntroduction, setSearchQuizIntroduction] = useState("")
   const [quizzes, setQuizzes] = useState([{
     id: "",
     quizTitle: "",
@@ -245,7 +248,8 @@ const QuizList: React.FC = () => {
     <>
     <QuizBookmarkContext.Provider
       value={{
-        text, setText,
+        searchQuiztitle, setSearchQuiztitle,
+        searchQuizIntroduction, setSearchQuizIntroduction,
         quizzes, setQuizzes,
         quizzesForSearch, setQuizzesForSearch,
         quizBookmarks, setQuizBookmarks,

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -254,8 +254,8 @@ const QuizList: React.FC = () => {
         quizTags, setQuizTags
       }}>
       <QuizSearchForm />
-      {quizzes.map((quiz) => (
-        <>
+      {quizzes.map((quiz, index) => (
+        <div key={index}>
           <p>{ quiz.id }</p>
           <p>{ quiz.quizTitle }</p>
           <p>{ quiz.quizIntroduction }</p>
@@ -302,7 +302,7 @@ const QuizList: React.FC = () => {
           <QuizComment
             quizId={Number(quiz.id)}
           />
-        </>
+        </div>
         ))}
       </QuizBookmarkContext.Provider>
     </>

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -1,4 +1,5 @@
-import { Button, makeStyles, Theme } from "@material-ui/core";
+import { Button, IconButton, InputBase, makeStyles, Paper, Theme } from "@material-ui/core";
+import SearchIcon from '@material-ui/icons/Search';
 import { AuthContext } from "App";
 import { getAllQuizzes } from "lib/api/quizzes";
 import { getAllQuizBookmarks } from "lib/api/quiz_boolmarks";
@@ -8,8 +9,29 @@ import React, { useContext, useState, useEffect, createContext } from "react";
 import { Link, useLocation } from "react-router-dom";
 import QuizBookmarkButton from "./QuizBookmarkButton";
 import QuizComment from "./QuizComment";
+import QuizSearchForm from "./QuizSearchForm";
 
 export const QuizBookmarkContext = createContext({} as {
+  quizzes:{
+    id: string,
+    quizTitle: string,
+    quizIntroduction: string
+  }[]
+  setQuizzes: React.Dispatch<React.SetStateAction<{
+    id: string,
+    quizTitle: string,
+    quizIntroduction: string
+  }[]>>
+  quizzesForSearch:{
+    id: string,
+    quizTitle: string,
+    quizIntroduction: string
+  }[]
+  setQuizzesForSearch: React.Dispatch<React.SetStateAction<{
+    id: string,
+    quizTitle: string,
+    quizIntroduction: string
+  }[]>>
   quizBookmarks: {
     id: string,
     userId: string,
@@ -34,9 +56,24 @@ export const QuizBookmarkContext = createContext({} as {
   }[]>>
   quizComment: string
   setQuizComment :React.Dispatch<React.SetStateAction<string>>
+  text: string
+  setText :React.Dispatch<React.SetStateAction<string>>
 })
 
 const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: '2px 4px',
+    display: 'flex',
+    alignItems: 'center',
+    width: 400,
+  },
+  input: {
+    marginLeft: theme.spacing(1),
+    flex: 1,
+  },
+  iconButton: {
+    padding: 10,
+  },
   submitBtn: {
     marginTop: theme.spacing(2),
     flexGrow: 1,
@@ -50,7 +87,13 @@ const QuizList: React.FC = () => {
   const location = useLocation()
 
   const { currentUser } = useContext(AuthContext)
+  const [text, setText] = useState("")
   const [quizzes, setQuizzes] = useState([{
+    id: "",
+    quizTitle: "",
+    quizIntroduction: ""
+  }])
+  const [quizzesForSearch, setQuizzesForSearch] = useState([{
     id: "",
     quizTitle: "",
     quizIntroduction: ""
@@ -75,6 +118,7 @@ const QuizList: React.FC = () => {
       console.log(resUserQuizzes)
       if (resUserQuizzes?.status === 200) {
         setQuizzes(resUserQuizzes?.data.data)
+        setQuizzesForSearch(resUserQuizzes?.data.data)
         setQuizBookmarks(resAllBookmarks?.data.data)
         setQuizCommentHistory(resUserQuizzes?.data.dataComments)
       } else {
@@ -93,6 +137,7 @@ const QuizList: React.FC = () => {
       console.log(resQuizzes)
       if (resQuizzes?.status === 200) {
         setQuizzes(resQuizzes?.data.data)
+        setQuizzesForSearch(resQuizzes?.data.data)
         setQuizBookmarks(resAllBookmarks?.data.data)
         setQuizCommentHistory(resQuizComments?.data.data)
       } else {
@@ -121,6 +166,7 @@ const QuizList: React.FC = () => {
               allBookmark.id === res.quizId)
             )
         setQuizzes(bookmarkedQuizzes)
+        setQuizzesForSearch(bookmarkedQuizzes)
         setQuizBookmarks(resAllBookmarks?.data.data)
         setQuizCommentHistory(QuizComments)
       } else {
@@ -150,6 +196,10 @@ const QuizList: React.FC = () => {
   }, [quizzes])
 
   useEffect(() => {
+    console.log("quizzesForSearch", quizzesForSearch)
+  }, [quizzesForSearch])
+
+  useEffect(() => {
     console.log("quizBookmarks", quizBookmarks)
   }, [quizBookmarks])
 
@@ -161,10 +211,14 @@ const QuizList: React.FC = () => {
     <>
     <QuizBookmarkContext.Provider
       value={{
+        text, setText,
+        quizzes, setQuizzes,
+        quizzesForSearch, setQuizzesForSearch,
         quizBookmarks, setQuizBookmarks,
         quizCommentHistory, setQuizCommentHistory,
         quizComment, setQuizComment
       }}>
+      <QuizSearchForm />
       {quizzes.map((quiz) => (
         <>
           <p>{ quiz.id }</p>

--- a/frontend/app/src/components/pages/QuizNewArrivalsOrderButton.tsx
+++ b/frontend/app/src/components/pages/QuizNewArrivalsOrderButton.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@material-ui/core";
+import { useContext } from "react"
+import { QuizBookmarkContext } from "./QuizList";
+
+const QuizNewArrivalsOrderButton :React.FC = () => {
+  const {
+    quizzes, setQuizzes,
+  } = useContext(QuizBookmarkContext)
+
+  const handleSortByDateQuizzessubmit = () => {
+    const newArrivalsOrderQuizzes = quizzes.sort((a, b) => ((a.createdAt > b.createdAt) ? -1 : 1))
+    setQuizzes(quizzes.filter(quiz => !quiz.id))
+    newArrivalsOrderQuizzes.map(newArrivalsOrderQuiz =>
+      setQuizzes(quizzes => [...quizzes,{
+        id: newArrivalsOrderQuiz.id,
+        quizTitle: newArrivalsOrderQuiz.quizTitle,
+        quizIntroduction: newArrivalsOrderQuiz.quizIntroduction,
+        createdAt: newArrivalsOrderQuiz.createdAt
+      }])
+    )
+  }
+
+  return(
+    <Button
+      type="submit"
+      variant="contained"
+      size="large"
+      color="default"
+      onClick={e => handleSortByDateQuizzessubmit()}
+      >
+      新着順
+    </Button>
+  )
+}
+
+export default QuizNewArrivalsOrderButton

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -53,6 +53,19 @@ const QuizSearchForm :React.FC = () => {
     "reset --hard"
   ];
 
+  const quizInfoList = [
+    {
+      key: 1,
+      placeholder: "クイズ名検索",
+      quizProps: "quizTitle"
+    },
+    {
+      key: 2,
+      placeholder: "クイズ説明文検索",
+      quizProps: "quizIntroduction"
+    },
+  ]
+
   const searchQuizzes = (prop :string , text :string) => {
     setQuizzes(
       quizzesForSearch.filter((quiz :AboutQuizzesData) => quiz?.[prop].indexOf(text) != -1 )
@@ -61,68 +74,41 @@ const QuizSearchForm :React.FC = () => {
 
   return(
     <>
-      <Paper
-        component="form"
-        className={classes.root}
-        >
-        <InputBase
-          className={classes.input}
-          placeholder="クイズ名検索"
-          value={text}
-          onChange={(event) => setText(event.target.value)}
-          onKeyPress={e =>{
-            if (e.key === "Enter") {
+      {quizInfoList.map((quizInfo) =>
+      <div key={quizInfo.key}>
+        <Paper
+          component="form"
+          className={classes.root}
+          >
+          <InputBase
+            className={classes.input}
+            placeholder={quizInfo.placeholder}
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            onKeyPress={e =>{
+              if (e.key === "Enter") {
+                e.preventDefault()
+                if(text === "") return
+                setText("")
+                searchQuizzes(quizInfo.quizProps, text)
+              }
+            }}
+            />
+          <IconButton
+            type="submit"
+            className={classes.iconButton}
+            aria-label="search"
+            onClick={e =>{
               e.preventDefault()
               if(text === "") return
-              setText("")
               searchQuizzes("quizTitle", text)
-            }
-          }}
-          />
-        <IconButton
-          type="submit"
-          className={classes.iconButton}
-          aria-label="search"
-          onClick={e =>{
-            e.preventDefault()
-            if(text === "") return
-            searchQuizzes("quizTitle", text)
-          } }
-          >
-          <SearchIcon />
-        </IconButton>
-      </Paper>
-      <Paper
-        component="form"
-        className={classes.root}
-        >
-        <InputBase
-          className={classes.input}
-          placeholder="クイズ説明文検索"
-          value={text}
-          onChange={(event) => setText(event.target.value)}
-          onKeyPress={e =>{
-            if (e.key === "Enter") {
-              e.preventDefault()
-              if(text === "") return
-              setText("")
-              searchQuizzes("quizIntroduction", text)
-            }
-          }}
-          />
-        <IconButton
-          type="submit"
-          className={classes.iconButton}
-          aria-label="search"
-          onClick={e =>{
-            e.preventDefault()
-            if(text === "") return
-            searchQuizzes("quizIntroduction", text)
-          } }
-          >
-          <SearchIcon />
-        </IconButton>
-      </Paper>
+            } }
+            >
+            <SearchIcon />
+          </IconButton>
+        </Paper>
+      </div>
+      )}
       <QuizNewArrivalsOrderButton />
       <QuizBookmarkOrderButton />
       <QuizResetSearchStatusButton />

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -27,7 +27,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 const QuizSearchForm :React.FC = () => {
   const classes = useStyles()
   const {
-    text, setText,
+    searchQuiztitle, setSearchQuiztitle,
+    searchQuizIntroduction, setSearchQuizIntroduction,
     setQuizzes,
     quizzesForSearch
   } = useContext(QuizBookmarkContext)
@@ -57,12 +58,16 @@ const QuizSearchForm :React.FC = () => {
     {
       key: 1,
       placeholder: "クイズ名検索",
-      quizProps: "quizTitle"
+      quizProps: "quizTitle",
+      searchState: searchQuiztitle,
+      searchSetState: setSearchQuiztitle
     },
     {
       key: 2,
       placeholder: "クイズ説明文検索",
-      quizProps: "quizIntroduction"
+      quizProps: "quizIntroduction",
+      searchState: searchQuizIntroduction,
+      searchSetState: setSearchQuizIntroduction
     },
   ]
 
@@ -83,14 +88,14 @@ const QuizSearchForm :React.FC = () => {
           <InputBase
             className={classes.input}
             placeholder={quizInfo.placeholder}
-            value={text}
-            onChange={(event) => setText(event.target.value)}
+            value={quizInfo.searchState}
+            onChange={(event) => quizInfo.searchSetState(event.target.value)}
             onKeyPress={e =>{
               if (e.key === "Enter") {
                 e.preventDefault()
-                if(text === "") return
-                setText("")
-                searchQuizzes(quizInfo.quizProps, text)
+                if(quizInfo.searchState === "") return
+                quizInfo.searchSetState("")
+                searchQuizzes(quizInfo.quizProps, quizInfo.searchState)
               }
             }}
             />
@@ -100,8 +105,8 @@ const QuizSearchForm :React.FC = () => {
             aria-label="search"
             onClick={e =>{
               e.preventDefault()
-              if(text === "") return
-              searchQuizzes("quizTitle", text)
+              if(quizInfo.searchState === "") return
+              searchQuizzes(quizInfo.quizProps, quizInfo.searchState)
             } }
             >
             <SearchIcon />

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -2,6 +2,7 @@ import { IconButton, InputBase, makeStyles, Paper, Theme } from "@material-ui/co
 import SearchIcon from '@material-ui/icons/Search';
 import { AboutQuizzesData } from "interfaces";
 import { useContext } from "react";
+import QuizBookmarkOrderButton from "./QuizBookmarkOrderButton";
 import { QuizBookmarkContext } from "./QuizList";
 import QuizNewArrivalsOrderButton from "./QuizNewArrivalsOrderButton";
 import QuizTagSearch from "./QuizTagSearchButton";
@@ -122,6 +123,7 @@ const QuizSearchForm :React.FC = () => {
         </IconButton>
       </Paper>
       <QuizNewArrivalsOrderButton />
+      <QuizBookmarkOrderButton />
       {tagLists.map((tagList) =>
         <QuizTagSearch
           key={tagList}

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -29,6 +29,27 @@ const QuizSearchForm :React.FC = () => {
     quizzesForSearch
   } = useContext(QuizBookmarkContext)
 
+  const tagLists = [
+    "add" ,
+    "commit",
+    "commit --amend",
+    "push",
+    "push -d",
+    "branch",
+    "branch -d",
+    "branch -D",
+    "branch -m",
+    "checkout",
+    "checkout -b",
+    "touch",
+    "rm",
+    "rm --cashed",
+    "reset",
+    "reset --soft",
+    "reset --mixed",
+    "reset --hard"
+  ];
+
   const searchQuizzes = (prop :string , text :string) => {
     setQuizzes(
       quizzesForSearch.filter((quiz :AboutQuizzesData) => quiz?.[prop].indexOf(text) != -1 )
@@ -99,6 +120,10 @@ const QuizSearchForm :React.FC = () => {
           <SearchIcon />
         </IconButton>
       </Paper>
+
+      {tagLists.map(tagList =>
+        <QuizTagSearch tagName={tagList} />
+        )}
     </>
   )
 }

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -1,0 +1,71 @@
+import { IconButton, InputBase, makeStyles, Paper, Theme } from "@material-ui/core";
+import SearchIcon from '@material-ui/icons/Search';
+import { useContext } from "react";
+import { QuizBookmarkContext } from "./QuizList";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: '2px 4px',
+    display: 'flex',
+    alignItems: 'center',
+    width: 400,
+  },
+  input: {
+    marginLeft: theme.spacing(1),
+    flex: 1,
+  },
+  iconButton: {
+    padding: 10,
+  }
+}))
+
+const QuizSearchForm :React.FC = () => {
+  const classes = useStyles()
+  const {
+    text, setText,
+    setQuizzes,
+    quizzesForSearch
+  } = useContext(QuizBookmarkContext)
+
+  const searchQuizzes = (text :string) => {
+    setQuizzes(
+      quizzesForSearch.filter(quiz => quiz.quizTitle.indexOf(text) != -1 )
+    )
+  }
+
+  return(
+    <Paper
+      component="form"
+      className={classes.root}
+      >
+          <InputBase
+              className={classes.input}
+              placeholder="クイズ名検索"
+              value={text}
+              onChange={(event) => setText(event.target.value)}
+              onKeyPress={e =>{
+                if (e.key === "Enter") {
+                  e.preventDefault()
+                  if(text === "") return
+                  setText("")
+                  searchQuizzes(text)
+                }
+              }}
+            />
+          <IconButton
+            type="submit"
+            className={classes.iconButton}
+            aria-label="search"
+            onClick={e =>{
+              e.preventDefault()
+              if(text === "") return
+              searchQuizzes(text)
+            } }
+            >
+            <SearchIcon />
+          </IconButton>
+        </Paper>
+  )
+}
+
+export default QuizSearchForm

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -3,6 +3,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import { AboutQuizzesData } from "interfaces";
 import { useContext } from "react";
 import { QuizBookmarkContext } from "./QuizList";
+import QuizNewArrivalsOrderButton from "./QuizNewArrivalsOrderButton";
 import QuizTagSearch from "./QuizTagSearchButton";
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -120,9 +121,12 @@ const QuizSearchForm :React.FC = () => {
           <SearchIcon />
         </IconButton>
       </Paper>
-
-      {tagLists.map(tagList =>
-        <QuizTagSearch tagName={tagList} />
+      <QuizNewArrivalsOrderButton />
+      {tagLists.map((tagList) =>
+        <QuizTagSearch
+          key={tagList}
+          tagName={tagList}
+          />
         )}
     </>
   )

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -5,6 +5,7 @@ import { useContext } from "react";
 import QuizBookmarkOrderButton from "./QuizBookmarkOrderButton";
 import { QuizBookmarkContext } from "./QuizList";
 import QuizNewArrivalsOrderButton from "./QuizNewArrivalsOrderButton";
+import QuizResetSearchStatusButton from "./QuizSearchResetButton";
 import QuizTagSearch from "./QuizTagSearchButton";
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -124,6 +125,7 @@ const QuizSearchForm :React.FC = () => {
       </Paper>
       <QuizNewArrivalsOrderButton />
       <QuizBookmarkOrderButton />
+      <QuizResetSearchStatusButton />
       {tagLists.map((tagList) =>
         <QuizTagSearch
           key={tagList}

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -1,7 +1,9 @@
 import { IconButton, InputBase, makeStyles, Paper, Theme } from "@material-ui/core";
 import SearchIcon from '@material-ui/icons/Search';
+import { AboutQuizzesData } from "interfaces";
 import { useContext } from "react";
 import { QuizBookmarkContext } from "./QuizList";
+import QuizTagSearch from "./QuizTagSearchButton";
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -27,44 +29,77 @@ const QuizSearchForm :React.FC = () => {
     quizzesForSearch
   } = useContext(QuizBookmarkContext)
 
-  const searchQuizzes = (text :string) => {
+  const searchQuizzes = (prop :string , text :string) => {
     setQuizzes(
-      quizzesForSearch.filter(quiz => quiz.quizTitle.indexOf(text) != -1 )
+      quizzesForSearch.filter((quiz :AboutQuizzesData) => quiz?.[prop].indexOf(text) != -1 )
     )
   }
 
   return(
-    <Paper
-      component="form"
-      className={classes.root}
-      >
-          <InputBase
-              className={classes.input}
-              placeholder="クイズ名検索"
-              value={text}
-              onChange={(event) => setText(event.target.value)}
-              onKeyPress={e =>{
-                if (e.key === "Enter") {
-                  e.preventDefault()
-                  if(text === "") return
-                  setText("")
-                  searchQuizzes(text)
-                }
-              }}
-            />
-          <IconButton
-            type="submit"
-            className={classes.iconButton}
-            aria-label="search"
-            onClick={e =>{
+    <>
+      <Paper
+        component="form"
+        className={classes.root}
+        >
+        <InputBase
+          className={classes.input}
+          placeholder="クイズ名検索"
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          onKeyPress={e =>{
+            if (e.key === "Enter") {
               e.preventDefault()
               if(text === "") return
-              searchQuizzes(text)
-            } }
-            >
-            <SearchIcon />
-          </IconButton>
-        </Paper>
+              setText("")
+              searchQuizzes("quizTitle", text)
+            }
+          }}
+          />
+        <IconButton
+          type="submit"
+          className={classes.iconButton}
+          aria-label="search"
+          onClick={e =>{
+            e.preventDefault()
+            if(text === "") return
+            searchQuizzes("quizTitle", text)
+          } }
+          >
+          <SearchIcon />
+        </IconButton>
+      </Paper>
+      <Paper
+        component="form"
+        className={classes.root}
+        >
+        <InputBase
+          className={classes.input}
+          placeholder="クイズ説明文検索"
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          onKeyPress={e =>{
+            if (e.key === "Enter") {
+              e.preventDefault()
+              if(text === "") return
+              setText("")
+              searchQuizzes("quizIntroduction", text)
+            }
+          }}
+          />
+        <IconButton
+          type="submit"
+          className={classes.iconButton}
+          aria-label="search"
+          onClick={e =>{
+            e.preventDefault()
+            if(text === "") return
+            searchQuizzes("quizIntroduction", text)
+          } }
+          >
+          <SearchIcon />
+        </IconButton>
+      </Paper>
+    </>
   )
 }
 

--- a/frontend/app/src/components/pages/QuizSearchResetButton.tsx
+++ b/frontend/app/src/components/pages/QuizSearchResetButton.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@material-ui/core";
+import { useContext } from "react"
+import { QuizBookmarkContext } from "./QuizList";
+
+const QuizResetSearchStatusButton :React.FC = () => {
+  const {
+    quizzes, setQuizzes,
+    quizzesForSearch
+  } = useContext(QuizBookmarkContext)
+
+  const handleResetSearchStatusSubmit = () => {
+    const resetSearchStatusQuizzes = quizzesForSearch.sort((a, b) => (a.id < b.id ? -1 : 1))
+
+    setQuizzes(quizzes.filter(quiz => !quiz.id))
+    resetSearchStatusQuizzes.map(resetSearchStatusQuiz =>
+      setQuizzes(quizzes => [...quizzes,{
+        id: resetSearchStatusQuiz.id,
+        quizTitle: resetSearchStatusQuiz.quizTitle,
+        quizIntroduction: resetSearchStatusQuiz.quizIntroduction,
+        createdAt: resetSearchStatusQuiz.createdAt
+      }])
+    )
+  }
+
+  return(
+    <Button
+      type="submit"
+      variant="contained"
+      size="large"
+      color="default"
+      onClick={e => handleResetSearchStatusSubmit()}
+    >
+      reset
+    </Button>
+  )
+}
+
+export default QuizResetSearchStatusButton

--- a/frontend/app/src/components/pages/QuizTagSearchButton.tsx
+++ b/frontend/app/src/components/pages/QuizTagSearchButton.tsx
@@ -1,0 +1,46 @@
+import { Button, makeStyles, Theme } from "@material-ui/core";
+import { AboutQuizzesData } from "interfaces";
+import { useContext } from "react"
+import { QuizBookmarkContext } from "./QuizList";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  btn: {
+    textTransform: 'none',
+  }
+}))
+
+const QuizTagSearch :React.FC<{ tagName :string }> = ({tagName}) => {
+  const classes = useStyles()
+  const {
+    quizTags,
+    quizzesForSearch,
+    setQuizzes
+  } = useContext(QuizBookmarkContext)
+
+
+  const filetedQuizTags = quizTags.filter(quizTag => quizTag.tag === tagName )
+  const tagSearch = () =>  {
+    setQuizzes(
+      quizzesForSearch.filter((quiz :AboutQuizzesData) =>
+        filetedQuizTags.some(filetedQuizTag =>
+          filetedQuizTag.quizId === Number(quiz.id)
+          )
+        )
+    )
+  }
+
+  return (
+    <Button
+      type="submit"
+      variant="contained"
+      size="large"
+      color="default"
+      onClick={e => tagSearch()}
+      className={classes.btn}
+      >
+      {tagName + filetedQuizTags.length + "件" }
+    </Button>
+  )
+}
+
+export default QuizTagSearch

--- a/frontend/app/src/interfaces/index.ts
+++ b/frontend/app/src/interfaces/index.ts
@@ -81,6 +81,13 @@ export interface AboutQuizData {
   userId: number | undefined
 }
 
+export interface AboutQuizzesData  {
+  id: string
+  quizTitle: string
+  quizIntroduction: string
+  [key: string]: string;
+}
+
 export interface QuizFirtsOrLastData {
   quizFirstOrLastStatus: string
   quizId : number

--- a/frontend/app/src/lib/api/quiz_tags.ts
+++ b/frontend/app/src/lib/api/quiz_tags.ts
@@ -1,6 +1,10 @@
 import { createQuizTagData } from "interfaces"
 import client from "lib/api/client"
 
+export const getAllQuizTags = () => {
+  return client.get("quiz_tags")
+}
+
 export const createQuizTag = (data: createQuizTagData) => {
   return client.post("quiz_tags", data)
 }


### PR DESCRIPTION
概要
--
close #21 

行ったこと
--
■backend
【quiz_tags_controllerにquiz_tagsの全データを取得するためにindexアクションを追加】
pathが全クイズデータを取得して表示する"quiz/list"の際に、クイズごとにどのタグが紐づいているか判別するために全てのquiz_tagデータが必要なため、indexアクションを追加。

【indexアクションのテストを追加】
quiz_tags_controllerにindexアクションを追加したことに伴い、テストを追加。

■frontend
【検索機能用のuseStateを追加】
検索時にquizzesの配列をfilterメソッドで絞り込んだ後に、元々取得していたクイズのデータから絞りこみを行うためにDBから取得した時から変更が加えられていない配列が必要だったため、リロード時にquizzesと同じ情報が格納されるquizzesForSearchという配列を作成

【検索フォームの実装】
クイズのタイトル/紹介文のそれぞれで検索が行えるフォームを作成。
フォームごとに入力した文字列が一致しているクイズの情報が表示される。

【タグ検索ボタンの実装】
タグごとにボタンが表示され、クリックした場合に指定したタグが関連しているクイズが表示される。

【ブックマーク数順/新着順でクイズを表示するボタンの実装】
ボタンを押した場合、現在表示されているクイズがブックマーク数/新着順でクイズが並び替えられるボタンを作成。
配列内の順番を並び替えた場合は画面が再描画されないため、最初に配列内の情報を削除してから並び替えた配列を格納する流れで実装している。

【検索状態をresetをするボタンの実装】
クイズをブックマーク数やタグ名で絞った後に、全ての検索条件を一旦リセットする(リロード時に最初に表示されたクイズの状態に戻す)ボタンを作成。

行わなかったこと・その理由
--
特になし