### PR TITLE
クイズ一覧ページで作成者名を表示する機能を実装 

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -2,6 +2,23 @@ class Api::V1::UsersController < ApplicationController
   before_action :set_user, only: [:show, :update]
   before_action :user_params, only: [:update]
 
+  def index
+    users = User.preload(:quizzes)
+    users_hash = []
+    users.map do |user|
+      users_hash.push({
+        id: user.id,
+        user_name: user.user_name,
+        image: user.image,
+      })
+    end
+    render json: {
+      status: 'SUCCESS',
+      message: 'Loaded users',
+      data: users_hash,
+    }
+  end
+
   def show
     quizzes = @user.quizzes
     quiz_answer_records = @user.quiz_answer_records

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         resources :sessions, only: %i[index]
       end
 
-      resources :users, only: %i[show update]
+      resources :users, only: %i[index show update]
       resources :quizzes, only: %i[index create update show destroy] do
         member do
           get 'tag'

--- a/frontend/app/src/components/pages/QuizBookmarkOrderButton.tsx
+++ b/frontend/app/src/components/pages/QuizBookmarkOrderButton.tsx
@@ -16,6 +16,11 @@ const QuizBookmarkOrderButton :React.FC = () => {
     newArrivalsOrderQuizzes.map(newArrivalsOrderQuiz =>
       setQuizzes(quizzes => [...quizzes,{
         id: newArrivalsOrderQuiz.id,
+        userId: newArrivalsOrderQuiz.userId,
+        parentUserName: newArrivalsOrderQuiz.parentUserName,
+        parentUserImage: {
+          url: newArrivalsOrderQuiz.parentUserImage.url
+        },
         quizTitle: newArrivalsOrderQuiz.quizTitle,
         quizIntroduction: newArrivalsOrderQuiz.quizIntroduction,
         createdAt: newArrivalsOrderQuiz.createdAt

--- a/frontend/app/src/components/pages/QuizNewArrivalsOrderButton.tsx
+++ b/frontend/app/src/components/pages/QuizNewArrivalsOrderButton.tsx
@@ -13,6 +13,11 @@ const QuizNewArrivalsOrderButton :React.FC = () => {
     newArrivalsOrderQuizzes.map(newArrivalsOrderQuiz =>
       setQuizzes(quizzes => [...quizzes,{
         id: newArrivalsOrderQuiz.id,
+        userId: newArrivalsOrderQuiz.userId,
+        parentUserName: newArrivalsOrderQuiz.parentUserName,
+        parentUserImage: {
+          url: newArrivalsOrderQuiz.parentUserImage.url
+        },
         quizTitle: newArrivalsOrderQuiz.quizTitle,
         quizIntroduction: newArrivalsOrderQuiz.quizIntroduction,
         createdAt: newArrivalsOrderQuiz.createdAt

--- a/frontend/app/src/components/pages/QuizSearchForm.tsx
+++ b/frontend/app/src/components/pages/QuizSearchForm.tsx
@@ -1,6 +1,5 @@
 import { IconButton, InputBase, makeStyles, Paper, Theme } from "@material-ui/core";
 import SearchIcon from '@material-ui/icons/Search';
-import { AboutQuizzesData } from "interfaces";
 import { useContext } from "react";
 import QuizBookmarkOrderButton from "./QuizBookmarkOrderButton";
 import { QuizBookmarkContext } from "./QuizList";
@@ -71,9 +70,9 @@ const QuizSearchForm :React.FC = () => {
     },
   ]
 
-  const searchQuizzes = (prop :string , text :string) => {
+  const searchQuizzes = (prop :string, text :string) => {
     setQuizzes(
-      quizzesForSearch.filter((quiz :AboutQuizzesData) => quiz?.[prop].indexOf(text) != -1 )
+      quizzesForSearch.filter((quiz :any) => quiz?.[prop].indexOf(text) != -1 )
     )
   }
 

--- a/frontend/app/src/components/pages/QuizSearchResetButton.tsx
+++ b/frontend/app/src/components/pages/QuizSearchResetButton.tsx
@@ -15,6 +15,11 @@ const QuizResetSearchStatusButton :React.FC = () => {
     resetSearchStatusQuizzes.map(resetSearchStatusQuiz =>
       setQuizzes(quizzes => [...quizzes,{
         id: resetSearchStatusQuiz.id,
+        userId: resetSearchStatusQuiz.userId,
+        parentUserName: resetSearchStatusQuiz.parentUserName,
+        parentUserImage: {
+          url: resetSearchStatusQuiz.parentUserImage.url
+        },
         quizTitle: resetSearchStatusQuiz.quizTitle,
         quizIntroduction: resetSearchStatusQuiz.quizIntroduction,
         createdAt: resetSearchStatusQuiz.createdAt

--- a/frontend/app/src/interfaces/index.ts
+++ b/frontend/app/src/interfaces/index.ts
@@ -83,9 +83,14 @@ export interface AboutQuizData {
 
 export interface AboutQuizzesData  {
   id: string
+  userId: string
+  parentUserName: string
+  parentUserImage: {
+    url: string
+  }
   quizTitle: string
   quizIntroduction: string
-  [key: string]: string;
+  // [key: string]: string;
 }
 
 export interface QuizFirtsOrLastData {

--- a/frontend/app/src/lib/api/users.ts
+++ b/frontend/app/src/lib/api/users.ts
@@ -3,6 +3,10 @@ import Cookies from "js-cookie"
 
 import { UpdateUserFormData, ChangeUserPasswordFormData, ForgetUserPasswordFormData } from "interfaces/index"
 
+export const getAllUsers = () => {
+  return client.get("users")
+}
+
 export const updateUser = (id: number | undefined | null, data: UpdateUserFormData) => {
   return client.put(`/users/${id}`, data)
 }


### PR DESCRIPTION
概要
--
close #23 

行ったこと
--
■backend
【users_controllerにindexアクションとテストを追加】
indexアクションのテストは、create_listを用いて複数作成したuserデータのみを使用し、each_with_indexメソッドでデータの中身をテストする下記のコードのような形式にした方がテストコードが読みやすいと考えた。

~~~
※関連しているindexアクションのテストのコード
let!(:users) { create_list(:user, 5) }

    it "全てのuser_id/user_name/image_urlのデータを取得できていること" do
      users.each_with_index do |user, i|
        expect(res["data"][i]["id"]).to eq(user.id)
        expect(res["data"][i]["user_name"]).to eq(user.user_name)
        expect(res["data"][i]["image"]["url"]).to eq(user.image.url)
      end
    end
~~~


そのため、元々テスト全体に適用される箇所でデータを作成していた"let"の記述を書くアクションのテストの位置に移動した。

■frontend
【user/indexアクションから取得したデータを格納する配列(useState)を作成】
当初はusersという配列を作成し、quizzes/quizzesForSearchに格納されているuserIdに関連しているuser名とトップ画像をfilterメソッドを用いて表示されるように記述する予定だったが、表示スピードが遅かった。
そのためquizzes/quizzesForSearchの配列に関連しているuserのid/名前/画像urlのデータを格納し表示するという形に変更。

【取得したuserのidとクイズのuser_idが一致しているuser名がクイズごとに表示される処理を記述】
quizzees/quizzesForSearchの配列にuserの情報を格納しているため、mapメソッドで繰り返し表示されるように記述している箇所にuser名とプロフィール画像の記述を追加。


行わなかったこと・その理由
--
得意なし
