### PR TITLE
クイズ内のbranch/file等のデータ作成を制限する設定

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -6,6 +6,8 @@ Rails:
 
 Layout/LineLength:
   Max: 120
+  Exclude:
+    - 'spec/models/quiz_history_of_committed_file_spec.rb'
 
 AllCops:
   Exclude:

--- a/backend/app/models/quiz_branch.rb
+++ b/backend/app/models/quiz_branch.rb
@@ -1,4 +1,6 @@
 class QuizBranch < ApplicationRecord
+  MAX_QUIZ_BRANCHES_COUNT = 3
+
   belongs_to :quiz_first_or_last
   has_many :quiz_commit_messages, dependent: :destroy
   has_many :quiz_worktree_files, dependent: :destroy
@@ -7,4 +9,13 @@ class QuizBranch < ApplicationRecord
   has_many :quiz_repository_files, dependent: :destroy
 
   validates :quiz_branch_name, presence: true
+  validate :quiz_branches_count_must_be_within_limit
+
+  private
+
+  def quiz_branches_count_must_be_within_limit
+    if quiz_first_or_last.quiz_branches.count >= MAX_QUIZ_BRANCHES_COUNT
+      errors.add(:base, "quiz_branches count limit: #{MAX_QUIZ_BRANCHES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_commit_message.rb
+++ b/backend/app/models/quiz_commit_message.rb
@@ -1,7 +1,18 @@
 class QuizCommitMessage < ApplicationRecord
+  MAX_QUIZ_COMMIT_MESSAGES_COUNT = 10
+
   belongs_to :quiz_branch
   has_many :quiz_history_of_committed_files, dependent: :destroy
   has_many :quiz_repository_files, dependent: :destroy
 
   validates :quiz_commit_message, presence: true
+  validate :quiz_commit_messages_count_must_be_within_limit
+
+  private
+
+  def quiz_commit_messages_count_must_be_within_limit
+    if quiz_branch.quiz_commit_messages.count >= MAX_QUIZ_COMMIT_MESSAGES_COUNT
+      errors.add(:base, "quiz_commit_messages count limit: #{MAX_QUIZ_COMMIT_MESSAGES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_history_of_committed_file.rb
+++ b/backend/app/models/quiz_history_of_committed_file.rb
@@ -1,7 +1,26 @@
 class QuizHistoryOfCommittedFile < ApplicationRecord
+  MAX_PARENT_COMMIT_TYPE_COUNT = 3
+
   belongs_to :quiz_branch
   belongs_to :quiz_commit_message
 
   validates :quiz_history_of_committed_file_name, presence: true
   validates :quiz_history_of_committed_file_status, presence: true
+
+  validate :quiz_history_of_committed_file_parent_commit_message_id_types_limit
+
+  private
+
+  def quiz_history_of_committed_file_parent_commit_message_id_types_limit
+    types_limit_hash = []
+    history_files_parent_same_branches = QuizHistoryOfCommittedFile.where(quiz_branch_id: quiz_branch_id)
+
+    history_files_parent_same_branches.each do |history_file|
+      types_limit_hash.push(history_file.quiz_commit_message_id)
+    end
+
+    if types_limit_hash.uniq.length >= MAX_PARENT_COMMIT_TYPE_COUNT && types_limit_hash.exclude?(quiz_commit_message_id)
+      errors.add(:base, "quiz_history_of_committed_file_parent_commit types limit: #{MAX_PARENT_COMMIT_TYPE_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_index_file.rb
+++ b/backend/app/models/quiz_index_file.rb
@@ -1,6 +1,18 @@
 class QuizIndexFile < ApplicationRecord
+  MAX_QUIZ_INDEX_FILES_COUNT = 8
+
   belongs_to :quiz_branch
 
   validates :quiz_index_file_name, presence: true
   validates :quiz_index_file_text_status, presence: true
+
+  validate :quiz_index_files_count_must_be_within_limit
+
+  private
+
+  def quiz_index_files_count_must_be_within_limit
+    if quiz_branch.quiz_index_files.count >= MAX_QUIZ_INDEX_FILES_COUNT
+      errors.add(:base, "quiz_index_files count limit: #{MAX_QUIZ_INDEX_FILES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_remote_branch.rb
+++ b/backend/app/models/quiz_remote_branch.rb
@@ -1,7 +1,19 @@
 class QuizRemoteBranch < ApplicationRecord
+  MAX_QUIZ_REMOTE_BRANCHES_COUNT = 3
+
   belongs_to :quiz_first_or_last
   has_many :quiz_remote_commit_messages, dependent: :destroy
   has_many :quiz_remote_repository_files, dependent: :destroy
 
   validates :quiz_remote_branch_name, presence: true
+
+  validate :quiz_remote_branches_count_must_be_within_limit
+
+  private
+
+  def quiz_remote_branches_count_must_be_within_limit
+    if quiz_first_or_last.quiz_remote_branches.count >= MAX_QUIZ_REMOTE_BRANCHES_COUNT
+      errors.add(:base, "quiz_remote_branches count limit: #{MAX_QUIZ_REMOTE_BRANCHES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_remote_commit_message.rb
+++ b/backend/app/models/quiz_remote_commit_message.rb
@@ -1,6 +1,18 @@
 class QuizRemoteCommitMessage < ApplicationRecord
+  MAX_QUIZ_REMOTE_COMMIT_MESSAGES_COUNT = 10
+
   belongs_to :quiz_remote_branch
   has_many :quiz_remote_repository_files, dependent: :destroy
 
   validates :quiz_remote_commit_message, presence: true
+
+  validate :quiz_remote_commit_messages_count_must_be_within_limit
+
+  private
+
+  def quiz_remote_commit_messages_count_must_be_within_limit
+    if quiz_remote_branch.quiz_remote_commit_messages.count >= MAX_QUIZ_REMOTE_COMMIT_MESSAGES_COUNT
+      errors.add(:base, "quiz_remote_commit_messages count limit: #{MAX_QUIZ_REMOTE_COMMIT_MESSAGES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_remote_repository_file.rb
+++ b/backend/app/models/quiz_remote_repository_file.rb
@@ -1,7 +1,19 @@
 class QuizRemoteRepositoryFile < ApplicationRecord
+  MAX_QUIZ_REMOTE_REPOSITORY_FILES_COUNT = 16
+
   belongs_to :quiz_remote_branch
   belongs_to :quiz_remote_commit_message
 
   validates :quiz_remote_repository_file_name, presence: true
   validates :quiz_remote_repository_file_text_status, presence: true
+
+  validate :quiz_remote_repository_files_count_must_be_within_limit
+
+  private
+
+  def quiz_remote_repository_files_count_must_be_within_limit
+    if quiz_remote_branch.quiz_remote_repository_files.count >= MAX_QUIZ_REMOTE_REPOSITORY_FILES_COUNT
+      errors.add(:base, "quiz_remote_repository_files count limit: #{MAX_QUIZ_REMOTE_REPOSITORY_FILES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_repository_file.rb
+++ b/backend/app/models/quiz_repository_file.rb
@@ -1,7 +1,19 @@
 class QuizRepositoryFile < ApplicationRecord
+  MAX_QUIZ_REPOSITORY_FILES_COUNT = 8
+
   belongs_to :quiz_branch
   belongs_to :quiz_commit_message
 
   validates :quiz_repository_file_name, presence: true
   validates :quiz_repository_file_text_status, presence: true
+
+  validate :quiz_repository_files_count_must_be_within_limit
+
+  private
+
+  def quiz_repository_files_count_must_be_within_limit
+    if quiz_branch.quiz_repository_files.count >= MAX_QUIZ_REPOSITORY_FILES_COUNT
+      errors.add(:base, "quiz_repository_files count limit: #{MAX_QUIZ_REPOSITORY_FILES_COUNT}")
+    end
+  end
 end

--- a/backend/app/models/quiz_worktree_file.rb
+++ b/backend/app/models/quiz_worktree_file.rb
@@ -1,6 +1,18 @@
 class QuizWorktreeFile < ApplicationRecord
+  MAX_QUIZ_WORKTREE_FILES_COUNT = 8
+
   belongs_to :quiz_branch
 
   validates :quiz_worktree_file_name, presence: true
   validates :quiz_worktree_file_text_status, presence: true
+
+  validate :quiz_worktree_files_count_must_be_within_limit
+
+  private
+
+  def quiz_worktree_files_count_must_be_within_limit
+    if quiz_branch.quiz_worktree_files.count >= MAX_QUIZ_WORKTREE_FILES_COUNT
+      errors.add(:base, "quiz_worktree_files count limit: #{MAX_QUIZ_WORKTREE_FILES_COUNT}")
+    end
+  end
 end

--- a/backend/spec/models/quiz_branch_spec.rb
+++ b/backend/spec/models/quiz_branch_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe QuizBranch, type: :model do
+  def err_message(obj, karam)
+    obj.errors.messages[karam]
+  end
+
   describe "validates presence" do
     context "全てのカラムに値が入力されている場合" do
       let(:branch) { create(:quiz_branch) }
@@ -33,6 +37,21 @@ RSpec.describe QuizBranch, type: :model do
         expect do
           branch.destroy
         end.to change(QuizWorktreeFile, :count).by(-1).and change(QuizIndexFile, :count).by(-1).and change(QuizCommitMessage, :count).by(-1).and change(QuizHistoryOfCommittedFile, :count).by(-1).and change(QuizRepositoryFile, :count).by(-1) # rubocop:disable Style/LineLength
+      end
+    end
+  end
+
+  describe "quiz_branches_count_must_be_within_limit" do
+    context "同じquiz_first_or_lastデータに紐づいたquiz_branchのデータが既に二つ存在する場合" do
+      let!(:quiz_first_or_last) { create(:quiz_first_or_last) }
+      let!(:branch) { create_list(:quiz_branch, 3, quiz_first_or_last: quiz_first_or_last) }
+      let(:new_branch) { build(:quiz_branch, quiz_first_or_last: quiz_first_or_last) }
+
+      it "新しいquiz_branchデータ作成が失敗すること" do
+        expect do
+          new_branch.save
+        end.to change(QuizBranch, :count).by(0)
+        expect(err_message(new_branch, :base)).to include "quiz_branches count limit: 3"
       end
     end
   end

--- a/backend/spec/models/quiz_branch_spec.rb
+++ b/backend/spec/models/quiz_branch_spec.rb
@@ -42,8 +42,20 @@ RSpec.describe QuizBranch, type: :model do
   end
 
   describe "quiz_branches_count_must_be_within_limit" do
-    context "同じquiz_first_or_lastデータに紐づいたquiz_branchのデータが既に二つ存在する場合" do
-      let!(:quiz_first_or_last) { create(:quiz_first_or_last) }
+    let!(:quiz_first_or_last) { create(:quiz_first_or_last) }
+
+    context "同じquiz_first_or_lastデータに紐づいたquiz_branchのデータ数が3つ未満の場合" do
+      let!(:branch) { create_list(:quiz_branch, 2, quiz_first_or_last: quiz_first_or_last) }
+      let(:new_branch) { build(:quiz_branch, quiz_first_or_last: quiz_first_or_last) }
+
+      it "新しいquiz_branchデータ作成が成功すること" do
+        expect do
+          new_branch.save
+        end.to change(QuizBranch, :count).by(+1)
+      end
+    end
+
+    context "同じquiz_first_or_lastデータに紐づいたquiz_branchのデータが既に3つ存在する場合" do
       let!(:branch) { create_list(:quiz_branch, 3, quiz_first_or_last: quiz_first_or_last) }
       let(:new_branch) { build(:quiz_branch, quiz_first_or_last: quiz_first_or_last) }
 

--- a/backend/spec/models/quiz_commit_message_spec.rb
+++ b/backend/spec/models/quiz_commit_message_spec.rb
@@ -43,8 +43,20 @@ RSpec.describe QuizCommitMessage, type: :model do
   end
 
   describe "quiz_commit_messages_count_must_be_within_limit" do
+    let!(:branch) { create(:quiz_branch) }
+
+    context "同じquiz_branchデータに紐づいたquiz_commit_messageのデータ数が10個未満の場合" do
+      let!(:commit_messages) { create_list(:quiz_commit_message, 9, quiz_branch: branch) }
+      let(:new_commit_message) { build(:quiz_commit_message, quiz_branch: branch) }
+
+      it "新しいquiz_commit_messageデータ作成が成功すること" do
+        expect do
+          new_commit_message.save
+        end.to change(QuizCommitMessage, :count).by(+1)
+      end
+    end
+
     context "同じquiz_branchデータに紐づいたquiz_commit_messageのデータが既に10個存在する場合" do
-      let!(:branch) { create(:quiz_branch) }
       let!(:commit_messages) { create_list(:quiz_commit_message, 10, quiz_branch: branch) }
       let(:new_commit_message) { build(:quiz_commit_message, quiz_branch: branch) }
 

--- a/backend/spec/models/quiz_first_or_last_spec.rb
+++ b/backend/spec/models/quiz_first_or_last_spec.rb
@@ -39,10 +39,21 @@ RSpec.describe QuizFirstOrLast, type: :model do
   end
 
   describe "quiz_first_or_lasts_count_must_be_within_limit" do
-    context "同じquizデータに紐づいたquiz_first_or_lastのデータが二つ存在する場合" do
-      let!(:quiz) { create(:quiz) }
-      let!(:quiz_first_or_last1) { create(:quiz_first_or_last, quiz: quiz) }
-      let!(:quiz_first_or_last2) { create(:quiz_first_or_last, quiz: quiz) }
+    let!(:quiz) { create(:quiz) }
+
+    context "同じquizデータに紐づいたquiz_first_or_lastのデータ数が2つ未満の場合" do
+      let!(:quiz_first_or_last) { create(:quiz_first_or_last, quiz: quiz) }
+      let(:new_quiz_first_or_last) { build(:quiz_first_or_last, quiz: quiz) }
+
+      it "新しいquiz_first_or_lastデータ作成が成功すること" do
+        expect do
+          new_quiz_first_or_last.save
+        end.to change(QuizFirstOrLast, :count).by(+1)
+      end
+    end
+
+    context "同じquizデータに紐づいたquiz_first_or_lastのデータが既に2個存在する場合" do
+      let!(:quiz_first_or_lasts) { create_list(:quiz_first_or_last, 2, quiz: quiz) }
       let(:new_quiz_first_or_last) { build(:quiz_first_or_last, quiz: quiz) }
 
       it "新しいquiz_first_or_lastデータ作成が失敗すること" do

--- a/backend/spec/models/quiz_first_or_last_spec.rb
+++ b/backend/spec/models/quiz_first_or_last_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe QuizFirstOrLast, type: :model do
       let!(:quiz_first_or_last2) { create(:quiz_first_or_last, quiz: quiz) }
       let(:new_quiz_first_or_last) { build(:quiz_first_or_last, quiz: quiz) }
 
-      it "エラーが出ること" do
+      it "新しいquiz_first_or_lastデータ作成が失敗すること" do
         expect do
           new_quiz_first_or_last.save
         end.to change(QuizFirstOrLast, :count).by(0)

--- a/backend/spec/models/quiz_history_of_committed_file_spec.rb
+++ b/backend/spec/models/quiz_history_of_committed_file_spec.rb
@@ -28,4 +28,44 @@ RSpec.describe QuizHistoryOfCommittedFile, type: :model do
       end
     end
   end
+
+  describe "quiz_history_of_committed_files_count_must_be_within_limit" do
+    let!(:branch) { create(:quiz_branch) }
+    let!(:commit_message1) { create(:quiz_commit_message, quiz_branch: branch) }
+    let!(:commit_message2) { create(:quiz_commit_message, quiz_branch: branch) }
+    let!(:commit_message3) { create(:quiz_commit_message, quiz_branch: branch) }
+    let!(:commit_message4) { create(:quiz_commit_message, quiz_branch: branch) }
+    let!(:commit_message5) { create(:quiz_commit_message, quiz_branch: branch) }
+
+    context "作成するquiz_history_of_committed_fileの各データに紐づくcommitMessageの種類が合計3つ以下の場合" do
+      let(:history_files1) { build_list(:quiz_history_of_committed_file, 8, quiz_branch: branch, quiz_commit_message: commit_message1) }
+      let(:history_files2) { build_list(:quiz_history_of_committed_file, 8, quiz_branch: branch, quiz_commit_message: commit_message2) }
+      let(:history_files3) { build_list(:quiz_history_of_committed_file, 8, quiz_branch: branch, quiz_commit_message: commit_message3) }
+      let(:history_files_list) { [history_files1, history_files2, history_files3] }
+
+      it "新しいquiz_history_of_committed_fileデータ作成が成功すること" do
+        history_files_list.each do |history_files|
+          history_files.each do |history_file|
+            expect do
+              history_file.save
+            end.to change(QuizHistoryOfCommittedFile, :count).by(+1)
+          end
+        end
+      end
+    end
+
+    context "各データに紐づくcommitMessageの種類が既に3つ存在している場合" do
+      let!(:history_files1) { create_list(:quiz_history_of_committed_file, 8, quiz_branch: branch, quiz_commit_message: commit_message1) }
+      let!(:history_files2) { create_list(:quiz_history_of_committed_file, 8, quiz_branch: branch, quiz_commit_message: commit_message2) }
+      let!(:history_files3) { create_list(:quiz_history_of_committed_file, 8, quiz_branch: branch, quiz_commit_message: commit_message3) }
+      let(:history_file4) { build(:quiz_history_of_committed_file, quiz_branch: branch, quiz_commit_message: commit_message4) }
+
+      it "4種類目のcommit_messegeに紐づいているquiz_history_of_committed_fileデータの作成が失敗すること" do
+        expect do
+          history_file4.save
+        end.to change(QuizHistoryOfCommittedFile, :count).by(0)
+        expect(history_file4.errors.messages[:base]).to include "quiz_history_of_committed_file_parent_commit types limit: 3"
+      end
+    end
+  end
 end

--- a/backend/spec/models/quiz_index_file_spec.rb
+++ b/backend/spec/models/quiz_index_file_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe QuizIndexFile, type: :model do
+  def err_message(obj, karam)
+    obj.errors.messages[karam]
+  end
+
   describe "validates presence" do
     context "全てのカラムに値が入力されている場合" do
       let(:index_file) { create(:quiz_index_file) }
@@ -25,6 +29,21 @@ RSpec.describe QuizIndexFile, type: :model do
       it "エラーになること" do
         index_file.valid?
         expect(index_file.errors.messages[:quiz_index_file_text_status]).to include "can't be blank"
+      end
+    end
+  end
+
+  describe "quiz_index_files_count_must_be_within_limit" do
+    context "同じquiz_branchデータに紐づいたquiz_index_fileのデータが既に8個存在する場合" do
+      let!(:branch) { create(:quiz_branch) }
+      let!(:index_files) { create_list(:quiz_index_file, 8, quiz_branch: branch) }
+      let(:new_index_file) { build(:quiz_index_file, quiz_branch: branch) }
+
+      it "新しいquiz_index_fileデータ作成が失敗すること" do
+        expect do
+          new_index_file.save
+        end.to change(QuizIndexFile, :count).by(0)
+        expect(err_message(new_index_file, :base)).to include "quiz_index_files count limit: 8"
       end
     end
   end

--- a/backend/spec/models/quiz_index_file_spec.rb
+++ b/backend/spec/models/quiz_index_file_spec.rb
@@ -34,8 +34,20 @@ RSpec.describe QuizIndexFile, type: :model do
   end
 
   describe "quiz_index_files_count_must_be_within_limit" do
+    let!(:branch) { create(:quiz_branch) }
+
+    context "同じquiz_branchデータに紐づいたquiz_index_fileのデータ数が8個未満の場合" do
+      let!(:index_files) { create_list(:quiz_index_file, 7, quiz_branch: branch) }
+      let(:new_index_file) { build(:quiz_index_file, quiz_branch: branch) }
+
+      it "新しいquiz_index_fileデータ作成が成功すること" do
+        expect do
+          new_index_file.save
+        end.to change(QuizIndexFile, :count).by(+1)
+      end
+    end
+
     context "同じquiz_branchデータに紐づいたquiz_index_fileのデータが既に8個存在する場合" do
-      let!(:branch) { create(:quiz_branch) }
       let!(:index_files) { create_list(:quiz_index_file, 8, quiz_branch: branch) }
       let(:new_index_file) { build(:quiz_index_file, quiz_branch: branch) }
 

--- a/backend/spec/models/quiz_remote_branch_spec.rb
+++ b/backend/spec/models/quiz_remote_branch_spec.rb
@@ -43,8 +43,20 @@ RSpec.describe QuizRemoteBranch, type: :model do
   end
 
   describe "quiz_remote_branches_count_must_be_within_limit" do
+    let!(:quiz_first_or_last) { create(:quiz_first_or_last) }
+
+    context "同じquiz_first_or_lastデータに紐づいたquiz_remote_branchのデータ数が3個未満の場合" do
+      let!(:remote_branch) { create_list(:quiz_remote_branch, 2, quiz_first_or_last: quiz_first_or_last) }
+      let(:new_remote_branch) { build(:quiz_remote_branch, quiz_first_or_last: quiz_first_or_last) }
+
+      it "新しいquiz_remote_branchデータ作成が成功すること" do
+        expect do
+          new_remote_branch.save
+        end.to change(QuizRemoteBranch, :count).by(+1)
+      end
+    end
+
     context "同じquiz_first_or_lastデータに紐づいたquiz_remote_branchのデータが既に3個存在する場合" do
-      let!(:quiz_first_or_last) { create(:quiz_first_or_last) }
       let!(:remote_branch) { create_list(:quiz_remote_branch, 3, quiz_first_or_last: quiz_first_or_last) }
       let(:new_remote_branch) { build(:quiz_remote_branch, quiz_first_or_last: quiz_first_or_last) }
 

--- a/backend/spec/models/quiz_remote_branch_spec.rb
+++ b/backend/spec/models/quiz_remote_branch_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe QuizRemoteBranch, type: :model do
+  def err_message(obj, karam)
+    obj.errors.messages[karam]
+  end
+
   describe "validates presence" do
     context "全てのカラムに値が入力されている場合" do
       let(:remote_branch) { create(:quiz_remote_branch) }
@@ -34,6 +38,21 @@ RSpec.describe QuizRemoteBranch, type: :model do
         expect do
           remote_branch.destroy
         end.to change(QuizRemoteCommitMessage, :count).by(-1).and change(QuizRemoteRepositoryFile, :count).by(-1)
+      end
+    end
+  end
+
+  describe "quiz_remote_branches_count_must_be_within_limit" do
+    context "同じquiz_first_or_lastデータに紐づいたquiz_remote_branchのデータが既に3個存在する場合" do
+      let!(:quiz_first_or_last) { create(:quiz_first_or_last) }
+      let!(:remote_branch) { create_list(:quiz_remote_branch, 3, quiz_first_or_last: quiz_first_or_last) }
+      let(:new_remote_branch) { build(:quiz_remote_branch, quiz_first_or_last: quiz_first_or_last) }
+
+      it "新しいquiz_remote_branchデータ作成が失敗すること" do
+        expect do
+          new_remote_branch.save
+        end.to change(QuizRemoteBranch, :count).by(0)
+        expect(err_message(new_remote_branch, :base)).to include "quiz_remote_branches count limit: 3"
       end
     end
   end

--- a/backend/spec/models/quiz_remote_commit_message_spec.rb
+++ b/backend/spec/models/quiz_remote_commit_message_spec.rb
@@ -40,8 +40,20 @@ RSpec.describe QuizRemoteCommitMessage, type: :model do
   end
 
   describe "quiz_remote_commit_messages_count_must_be_within_limit" do
+    let!(:remote_branch) { create(:quiz_remote_branch) }
+
+    context "同じquiz_branchデータに紐づいたquiz_commit_messageのデータ数が10個未満の場合" do
+      let!(:remote_commit_messages) { create_list(:quiz_remote_commit_message, 9, quiz_remote_branch: remote_branch) }
+      let(:new_remote_commit_message) { build(:quiz_remote_commit_message, quiz_remote_branch: remote_branch) }
+
+      it "新しいquiz_commit_messageデータ作成が成功すること" do
+        expect do
+          new_remote_commit_message.save
+        end.to change(QuizRemoteCommitMessage, :count).by(+1)
+      end
+    end
+
     context "同じquiz_branchデータに紐づいたquiz_commit_messageのデータが既に10個存在する場合" do
-      let!(:remote_branch) { create(:quiz_remote_branch) }
       let!(:remote_commit_messages) { create_list(:quiz_remote_commit_message, 10, quiz_remote_branch: remote_branch) }
       let(:new_remote_commit_message) { build(:quiz_remote_commit_message, quiz_remote_branch: remote_branch) }
 

--- a/backend/spec/models/quiz_remote_commit_message_spec.rb
+++ b/backend/spec/models/quiz_remote_commit_message_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe QuizRemoteCommitMessage, type: :model do
+  def err_message(obj, karam)
+    obj.errors.messages[karam]
+  end
+
   describe "validates presence" do
     context "全てのカラムに値が入力されている場合" do
       let(:remote_commit_message) { create(:quiz_remote_commit_message) }
@@ -31,6 +35,21 @@ RSpec.describe QuizRemoteCommitMessage, type: :model do
         expect do
           remote_commit_message.destroy
         end.to change(QuizRemoteRepositoryFile, :count).by(-1)
+      end
+    end
+  end
+
+  describe "quiz_remote_commit_messages_count_must_be_within_limit" do
+    context "同じquiz_branchデータに紐づいたquiz_commit_messageのデータが既に10個存在する場合" do
+      let!(:remote_branch) { create(:quiz_remote_branch) }
+      let!(:remote_commit_messages) { create_list(:quiz_remote_commit_message, 10, quiz_remote_branch: remote_branch) }
+      let(:new_remote_commit_message) { build(:quiz_remote_commit_message, quiz_remote_branch: remote_branch) }
+
+      it "新しいquiz_commit_messageデータ作成が失敗すること" do
+        expect do
+          new_remote_commit_message.save
+        end.to change(QuizRemoteCommitMessage, :count).by(0)
+        expect(err_message(new_remote_commit_message, :base)).to include "quiz_remote_commit_messages count limit: 10"
       end
     end
   end

--- a/backend/spec/models/quiz_remote_repository_file_spec.rb
+++ b/backend/spec/models/quiz_remote_repository_file_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe QuizRemoteRepositoryFile, type: :model do
   end
 
   describe "quiz_remote_repository_files_count_must_be_within_limit" do
-    let!(:remote_branch) { create(:quiz_remote_branch) }
+    let!(:branch) { create(:quiz_remote_branch) }
 
     def err_message(obj, karam)
       obj.errors.messages[karam]
     end
 
     context "同じquiz_branchデータに紐づいたquiz_remote_repository_fileのデータ数が16個未満の場合" do
-      let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 15, quiz_remote_branch: remote_branch) }
-      let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: remote_branch) }
+      let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 15, quiz_remote_branch: branch) }
+      let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: branch) }
 
       it "新しいquiz_remote_repository_fileデータ作成が成功すること" do
         expect do
@@ -56,8 +56,8 @@ RSpec.describe QuizRemoteRepositoryFile, type: :model do
     end
 
     context "同じquiz_branchデータに紐づいたquiz_remote_repository_fileのデータが既に16個存在する場合" do
-      let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 16, quiz_remote_branch: remote_branch) }
-      let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: remote_branch) }
+      let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 16, quiz_remote_branch: branch) }
+      let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: branch) }
 
       it "新しいquiz_remote_repository_fileデータ作成が失敗すること" do
         expect do

--- a/backend/spec/models/quiz_remote_repository_file_spec.rb
+++ b/backend/spec/models/quiz_remote_repository_file_spec.rb
@@ -36,4 +36,23 @@ RSpec.describe QuizRemoteRepositoryFile, type: :model do
       end
     end
   end
+
+  describe "quiz_remote_repository_files_count_must_be_within_limit" do
+    def err_message(obj, karam)
+      obj.errors.messages[karam]
+    end
+
+    context "同じquiz_branchデータに紐づいたquiz_remote_repository_fileのデータが既に8個存在する場合" do
+      let!(:remote_branch) { create(:quiz_remote_branch) }
+      let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 16, quiz_remote_branch: remote_branch) }
+      let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: remote_branch) }
+
+      it "新しいquiz_remote_repository_fileデータ作成が失敗すること" do
+        expect do
+          new_remote_repository_file.save
+        end.to change(QuizRemoteRepositoryFile, :count).by(0)
+        expect(err_message(new_remote_repository_file, :base)).to include "quiz_remote_repository_files count limit: 16"
+      end
+    end
+  end
 end

--- a/backend/spec/models/quiz_remote_repository_file_spec.rb
+++ b/backend/spec/models/quiz_remote_repository_file_spec.rb
@@ -38,12 +38,24 @@ RSpec.describe QuizRemoteRepositoryFile, type: :model do
   end
 
   describe "quiz_remote_repository_files_count_must_be_within_limit" do
+    let!(:remote_branch) { create(:quiz_remote_branch) }
+
     def err_message(obj, karam)
       obj.errors.messages[karam]
     end
 
-    context "同じquiz_branchデータに紐づいたquiz_remote_repository_fileのデータが既に8個存在する場合" do
-      let!(:remote_branch) { create(:quiz_remote_branch) }
+    context "同じquiz_branchデータに紐づいたquiz_remote_repository_fileのデータ数が16個未満の場合" do
+      let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 15, quiz_remote_branch: remote_branch) }
+      let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: remote_branch) }
+
+      it "新しいquiz_remote_repository_fileデータ作成が成功すること" do
+        expect do
+          new_remote_repository_file.save
+        end.to change(QuizRemoteRepositoryFile, :count).by(+1)
+      end
+    end
+
+    context "同じquiz_branchデータに紐づいたquiz_remote_repository_fileのデータが既に16個存在する場合" do
       let!(:remote_repository_files) { create_list(:quiz_remote_repository_file, 16, quiz_remote_branch: remote_branch) }
       let(:new_remote_repository_file) { build(:quiz_remote_repository_file, quiz_remote_branch: remote_branch) }
 

--- a/backend/spec/models/quiz_repository_file_spec.rb
+++ b/backend/spec/models/quiz_repository_file_spec.rb
@@ -28,4 +28,23 @@ RSpec.describe QuizRepositoryFile, type: :model do
       end
     end
   end
+
+  describe "quiz_repository_files_count_must_be_within_limit" do
+    def err_message(obj, karam)
+      obj.errors.messages[karam]
+    end
+
+    context "同じquiz_branchデータに紐づいたquiz_repository_fileのデータが既に8個存在する場合" do
+      let!(:branch) { create(:quiz_branch) }
+      let!(:repository_files) { create_list(:quiz_repository_file, 8, quiz_branch: branch) }
+      let(:new_repository_file) { build(:quiz_repository_file, quiz_branch: branch) }
+
+      it "新しいquiz_repository_fileデータ作成が失敗すること" do
+        expect do
+          new_repository_file.save
+        end.to change(QuizRepositoryFile, :count).by(0)
+        expect(err_message(new_repository_file, :base)).to include "quiz_repository_files count limit: 8"
+      end
+    end
+  end
 end

--- a/backend/spec/models/quiz_repository_file_spec.rb
+++ b/backend/spec/models/quiz_repository_file_spec.rb
@@ -30,8 +30,21 @@ RSpec.describe QuizRepositoryFile, type: :model do
   end
 
   describe "quiz_repository_files_count_must_be_within_limit" do
+    let!(:branch) { create(:quiz_branch) }
+
     def err_message(obj, karam)
       obj.errors.messages[karam]
+    end
+
+    context "同じquiz_branchデータに紐づいたquiz_repository_fileのデータ数が8個未満の場合" do
+      let!(:repository_files) { create_list(:quiz_repository_file, 7, quiz_branch: branch) }
+      let(:new_repository_file) { build(:quiz_repository_file, quiz_branch: branch) }
+
+      it "新しいquiz_repository_fileデータ作成が成功すること" do
+        expect do
+          new_repository_file.save
+        end.to change(QuizRepositoryFile, :count).by(+1)
+      end
     end
 
     context "同じquiz_branchデータに紐づいたquiz_repository_fileのデータが既に8個存在する場合" do

--- a/backend/spec/models/quiz_worktree_file_spec.rb
+++ b/backend/spec/models/quiz_worktree_file_spec.rb
@@ -34,8 +34,20 @@ RSpec.describe QuizWorktreeFile, type: :model do
   end
 
   describe "quiz_worktree_files_count_must_be_within_limit" do
+    let!(:branch) { create(:quiz_branch) }
+
+    context "同じquiz_branchデータに紐づいたquiz_worktree_fileのデータ数が8個未満の場合" do
+      let!(:worktree_files) { create_list(:quiz_worktree_file, 7, quiz_branch: branch) }
+      let(:new_worktree_file) { build(:quiz_worktree_file, quiz_branch: branch) }
+
+      it "新しいquiz_worktree_fileデータ作成が成功すること" do
+        expect do
+          new_worktree_file.save
+        end.to change(QuizWorktreeFile, :count).by(+1)
+      end
+    end
+
     context "同じquiz_branchデータに紐づいたquiz_worktree_fileのデータが既に8個存在する場合" do
-      let!(:branch) { create(:quiz_branch) }
       let!(:worktree_files) { create_list(:quiz_worktree_file, 8, quiz_branch: branch) }
       let(:new_worktree_file) { build(:quiz_worktree_file, quiz_branch: branch) }
 

--- a/backend/spec/models/quiz_worktree_file_spec.rb
+++ b/backend/spec/models/quiz_worktree_file_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe QuizWorktreeFile, type: :model do
+  def err_message(obj, karam)
+    obj.errors.messages[karam]
+  end
+
   describe "validates presence" do
     context "全てのカラムに値が入力されている場合" do
       let(:worktree_file) { create(:quiz_worktree_file) }
@@ -25,6 +29,21 @@ RSpec.describe QuizWorktreeFile, type: :model do
       it "エラーになること" do
         worktree_file.valid?
         expect(worktree_file.errors.messages[:quiz_worktree_file_text_status]).to include "can't be blank"
+      end
+    end
+  end
+
+  describe "quiz_worktree_files_count_must_be_within_limit" do
+    context "同じquiz_branchデータに紐づいたquiz_worktree_fileのデータが既に8個存在する場合" do
+      let!(:branch) { create(:quiz_branch) }
+      let!(:worktree_files) { create_list(:quiz_worktree_file, 8, quiz_branch: branch) }
+      let(:new_worktree_file) { build(:quiz_worktree_file, quiz_branch: branch) }
+
+      it "新しいquiz_worktree_fileデータ作成が失敗すること" do
+        expect do
+          new_worktree_file.save
+        end.to change(QuizWorktreeFile, :count).by(0)
+        expect(err_message(new_worktree_file, :base)).to include "quiz_worktree_files count limit: 8"
       end
     end
   end

--- a/backend/spec/requests/api/v1/quiz_first_or_lasts_spec.rb
+++ b/backend/spec/requests/api/v1/quiz_first_or_lasts_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
 
   describe "GET /show" do
     let!(:related_branchs) do
-      create_list(:quiz_branch, 5, quiz_first_or_last: first_or_last)
+      create_list(:quiz_branch, 3, quiz_first_or_last: first_or_last)
     end
     let!(:not_related_branch) do
       create(:quiz_branch, quiz_first_or_last: first_or_last2)
     end
     let!(:related_remote_branches) do
-      create_list(:quiz_remote_branch, 5, quiz_first_or_last: first_or_last)
+      create_list(:quiz_remote_branch, 3, quiz_first_or_last: first_or_last)
     end
     let!(:not_related_remote_branch) do
       create(:quiz_remote_branch, quiz_first_or_last: first_or_last2)
@@ -101,8 +101,8 @@ RSpec.describe "Api::V1::QuizFirstOrLasts", type: :request do
           expect(res["data_remote_branches"][i]["id"]).to eq(quiz_remote_branch.id)
           expect(res["data_remote_branches"][i]["id"]).not_to eq(not_related_remote_branch.id)
         end
-        expect(res["data_branches"].length).to eq 5
-        expect(res["data_remote_branches"].length).to eq 5
+        expect(res["data_branches"].length).to eq 3
+        expect(res["data_remote_branches"].length).to eq 3
         expect(response).to have_http_status(:success)
       end
 

--- a/frontend/app/src/components/pages/CreateQuizButton.tsx
+++ b/frontend/app/src/components/pages/CreateQuizButton.tsx
@@ -359,8 +359,8 @@ const CreateOrUpdateQuizButton: React.FC = () => {
       && !deleteBranches.some(deleteBranch => initWorkfile.parentBranch === deleteBranch.branchName)
     )
   const deleteIndexFiles =
-    initialIndexFiles.filter(initIndexFile => !indexFiles.some(indexFile =>
-      initIndexFile.indexFileId === indexFile.indexFileId
+    initialIndexFiles.filter(initIndexFile =>
+      !indexFiles.some(indexFile => initIndexFile.indexFileId === indexFile.indexFileId
       && !deleteBranches.some(deleteBranch => initIndexFile.parentBranch === deleteBranch.branchName)
     ))
   const deleteRepositoryFiles =
@@ -394,6 +394,16 @@ const CreateOrUpdateQuizButton: React.FC = () => {
 
   const handleUpdateQuizData = async (e: React.MouseEvent<HTMLButtonElement>) => {
     try {
+      await Promise.all(deleteBranches.map(deleteBranch => deleteQuizBranch(Number(deleteBranch.branchId))))
+      await Promise.all(deleteCommitMessages.map(deleteCommitMessage => deleteQuizCommitMessage(Number(deleteCommitMessage.commitMessageId))))
+      await Promise.all(deleteWorktreeFiles.map(deleteWorktreeFile => deleteQuizWorktreeFile(Number(deleteWorktreeFile.worktreeFileId))))
+      await Promise.all(deleteIndexFiles.map(deleteIndexFile => deleteQuizIndexFile(Number(deleteIndexFile.indexFileId))))
+      await Promise.all(deleteRepositoryFiles.map(deleteRepositoryFile => deleteQuizRepositoryFile(Number(deleteRepositoryFile.repositoryFileId))))
+      await Promise.all(deleteFileHistoryForCansellCommits.map(deleteFileHistoryForCansellCommit => deleteQuizHistoryOfCommittedFile(Number(deleteFileHistoryForCansellCommit.historyFileId))))
+      await Promise.all(deleteRemoteRepositoryFiles.map(deleteRemoteRepositoryFile => deleteQuizRemoteRepositoryFile(Number(deleteRemoteRepositoryFile.remoteRepositoryFileId))))
+      await Promise.all(deleteRemoteCommitMessages.map(deleteRemoteCommitMessage => deleteQuizRemoteCommitMessage(Number(deleteRemoteCommitMessage.remoteCommitMessageId))))
+      await Promise.all(deleteRemoteBranches.map(deleteRemoteBranch => deleteQuizRemoteBranch(Number(deleteRemoteBranch.remoteBranchId))))
+
       //新規作成用の関数(branchも新規作成の場合)
       await handleCreateQuizSubmit(
         createBranches,
@@ -505,16 +515,6 @@ const CreateOrUpdateQuizButton: React.FC = () => {
           }
         )
       })
-
-      deleteBranches.forEach(deleteBranch => deleteQuizBranch(Number(deleteBranch.branchId)))
-      deleteCommitMessages.forEach(deleteCommitMessage => deleteQuizCommitMessage(Number(deleteCommitMessage.commitMessageId)))
-      deleteWorktreeFiles.forEach(deleteWorktreeFile => deleteQuizWorktreeFile(Number(deleteWorktreeFile.worktreeFileId)))
-      deleteIndexFiles.forEach(deleteIndexFile => deleteQuizIndexFile(Number(deleteIndexFile.indexFileId)))
-      deleteRepositoryFiles.forEach(deleteRepositoryFile => deleteQuizRepositoryFile(Number(deleteRepositoryFile.repositoryFileId)))
-      deleteFileHistoryForCansellCommits.forEach(deleteFileHistoryForCansellCommit => deleteQuizHistoryOfCommittedFile(Number(deleteFileHistoryForCansellCommit.historyFileId)))
-      deleteRemoteRepositoryFiles.forEach(deleteRemoteRepositoryFile => deleteQuizRemoteRepositoryFile(Number(deleteRemoteRepositoryFile.remoteRepositoryFileId)))
-      deleteRemoteCommitMessages.forEach(deleteRemoteCommitMessage => deleteQuizRemoteCommitMessage(Number(deleteRemoteCommitMessage.remoteCommitMessageId)))
-      deleteRemoteBranches.forEach(deleteRemoteBranch => deleteQuizRemoteBranch(Number(deleteRemoteBranch.remoteBranchId)))
 
       //確認
       console.log("既存ブランチからworkFile新規作成",quizWorktreeFileRes)

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -152,11 +152,29 @@ const InputCommand: React.FC = () => {
   const gitCommitM = (text :string, str :number) => {
     const commonConditions = indexFiles.some(indexFile => indexFile.fileName !== "" && /[\S+]/.test(text.substring(str-1))) && !currentBranchParentCommitMessages.some(commitMessages => commitMessages.message === text.substring(str))
     const removeRepositoryFiles :any = []
+    const notRemoveCommitMessages = currentBranchParentCommitMessages.slice(-2)
 
     if ((commonConditions && !currentBranchParentIndexFiles.every(indexFile => currentBranchParentRepositoryFiles.some(repositoryFile => indexFile.fileName === repositoryFile.fileName && indexFile.textStatus === repositoryFile.textStatus)))
         || (commonConditions && !currentBranchParentRepositoryFiles.every(repositoryFile => currentBranchParentIndexFiles.some(indexFile => indexFile.fileName === repositoryFile.fileName && indexFile.textStatus === repositoryFile.textStatus)))
         || (commonConditions && !currentBranchParentRepositoryFiles.some(repositoryFile => repositoryFile.fileName))
       ) {
+      setFileHistoryForCansellCommits(fileHistoryForCansellCommits.map(historyFile =>
+        !notRemoveCommitMessages.some(commitMessage => commitMessage.message === historyFile.parentCommitMessage)
+          && historyFile.parentBranch === currentBranch.currentBranchName
+        ? {
+          fileName :"",
+          textStatus: "",
+          fileStatus: "",
+          pastTextStatus: "",
+          parentBranch: "",
+          parentCommitMessage: "",
+          parentPastCommitMessage: "",
+          parentBranchId: "",
+          parentCommitMessageId: "",
+          historyFileId: ""
+          }
+        : historyFile
+        ))
       setCommitMessages(commitMessage => [...commitMessage,{
         message: text.substring(str),
         parentBranch: currentBranch.currentBranchName,

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -50,6 +50,11 @@ const InputCommand: React.FC = () => {
   const exceptCurrentBranchParentIndexFiles = indexFiles.filter((indexFile) => indexFile.parentBranch !== currentBranch.currentBranchName)
   const differTextStatusRemoteRepositoryFiles = currentBranchParentRepositoryFiles.filter(repositoryFile => currentBranchParentRemoteRepositoryFiles.some(remoteRepositoryFile => repositoryFile.fileName === remoteRepositoryFile.fileName && repositoryFile.textStatus !== remoteRepositoryFile.textStatus))
 
+  const checkBranchCount = branches.filter(branch => branch.branchName).length
+  const checkGitAddACount = currentBranchParentWorktreeFiles.filter(worktreeFile => !currentBranchParentIndexFiles.some(indexFile => indexFile.fileName === worktreeFile.fileName)).length
+  const checkDatacount = (datas: any, prop: string = "parentBranch") => datas.filter((data :any) => data?.[prop] === currentBranch.currentBranchName).length
+  const checkMultiData = (text :string, str :number,datas: any, prop: string = "parentBranch") => afterCommandMultipleStrings(text, str)?.length + checkDatacount(datas, prop)
+
   const gitAddA = () => {
     setIndexFiles(indexFiles.map(indexFile =>
       !currentBranchParentWorktreeFiles.some(worktreeFile => worktreeFile.fileName === indexFile.fileName)
@@ -668,7 +673,8 @@ const InputCommand: React.FC = () => {
     const resetedCommitMessages :any = []
     const resetedHistoryFiles :any = []
     const forResetCurrentBranchCommitMessages = commitMessages.filter((commitMessage) => commitMessage.parentBranch === currentBranch.currentBranchName)
-    if (forResetCurrentBranchCommitMessages[forResetCurrentBranchCommitMessages.length -1].message) {
+    const commitMessageLength = forResetCurrentBranchCommitMessages.length
+    if (commitMessageLength >= resetNunber && forResetCurrentBranchCommitMessages[forResetCurrentBranchCommitMessages.length -1]) {
       for (let i = 0; i < resetNunber; i++){
         const lastestFileHistoryForCansellCommits = fileHistoryForCansellCommits.filter(fileHistory =>
           fileHistory.parentCommitMessage === forResetCurrentBranchCommitMessages[forResetCurrentBranchCommitMessages.length -1].message
@@ -961,6 +967,9 @@ const InputCommand: React.FC = () => {
     )
   }
 
+  const limitDataErrorMessage = (data: string, num: number) => setAddText(`error: 申し訳ありません。DBの容量確保のため${data}を作成できる数は${num}つまでになっています。`)
+  const resetFailedErrorMessage = () => setAddText(`error: 申し訳ありません。DBの容量確保のためgit resetで指定できる数は3以下の数字です。`)
+
   return(
     <Input
           className={classes.input}
@@ -978,11 +987,11 @@ const InputCommand: React.FC = () => {
               }])
               if (gitInit === "Initialized empty Git repository") {
                 if (text.startsWith("git add .") || text.startsWith("git add -A")){
-                  gitAddA()
+                  checkDatacount(indexFiles) + checkGitAddACount < 8 ? gitAddA() : limitDataErrorMessage("indexFiles", 8)
                 } else if (text === `git remote add https://git-used-to.com/${currentUser?.userName}`){
                   gitRemoteAdd()
                 } else if (text.startsWith("git add ")){
-                  gitAdd(text, 8)
+                  checkMultiData(text, 8, indexFiles) < 8 ? gitAdd(text, 8) : limitDataErrorMessage("indexFiles", 8)
                 } else if (text.startsWith("kakunin")){
                   forCheck(text, 8)
                 } else if (text.startsWith("kakunin2")){
@@ -990,9 +999,16 @@ const InputCommand: React.FC = () => {
                 } else if (text.startsWith("git commit --amend")){
                   gitCommitAmend(text, 19)
                 } else if (text.startsWith("git commit -m")){
-                  gitCommitM(text, 14)
+                  checkDatacount(repositoryFiles) < 8
+                    && checkDatacount(commitMessages) < 10
+                  ? gitCommitM(text, 14)
+                  : limitDataErrorMessage("repositoryFiles", 8)
                 } else if (text === `git push origin ${currentBranch.currentBranchName}`) {
-                  gitPush()
+                  checkDatacount(remoteBranches, "remoteBranchName") < 3
+                    && checkDatacount(remoteCommitMessages, "parentRemoteBranch") < 10
+                    && checkDatacount(remoteRepositoryFiles, "parentRemoteBranch") < 16
+                  ? gitPush()
+                  : limitDataErrorMessage("repositoryFiles", 16)
                 } else if (text.startsWith("git push --delete origin")) {
                   gitPushDelete(text, 25)
                 } else if (text.startsWith("git push origin :")) {
@@ -1004,24 +1020,21 @@ const InputCommand: React.FC = () => {
                 } else if (text.startsWith("git branch -d")) {
                   gitBranchD(text, 14)
                 } else if (text.startsWith("git branch ") && afterCommandBranchName.test(text.substring(11))){
-                  gitBranch(text, 11)
+                  checkBranchCount < 3 ? gitBranch(text, 11) : limitDataErrorMessage("branch", 3)
                 } else if (text.startsWith("git checkout -b ")) {
-                  gitCheckoutB(text, 16)
+                  checkBranchCount < 3 ? gitCheckoutB(text, 16) : limitDataErrorMessage("branch", 3)
                 } else if (text.startsWith("git checkout ")) {
                   gitCheckout(text, 13)
                 } else if (text.startsWith("touch ")) {
-                  touch(text, 6)
+                  checkMultiData(text, 6, worktreeFiles) < 8 ? touch(text, 6) : limitDataErrorMessage("worktreeFiles", 8)
                 } else if (text.startsWith("git rm --cashed")) {
                   gitRmCashed(text, 16)
                 } else if (text.startsWith("git reset --mixed HEAD~")) {
-                  gitResetOption(text, 23, "mixed")
-                  console.log("mixedです")
+                  Number(text.substring(23)) < 4 ? gitResetOption(text, 23, "mixed") : resetFailedErrorMessage()
                 } else if (text.startsWith("git reset --hard HEAD~")) {
-                  gitResetOption(text, 22, "hard")
-                  console.log("hardです")
+                  Number(text.substring(22)) < 4 ? gitResetOption(text, 22, "hard") : resetFailedErrorMessage()
                 } else if (text.startsWith("git reset --soft HEAD~")) {
-                  gitResetOption(text, 22, "soft")
-                  console.log("softです")
+                  Number(text.substring(22)) < 4 ? gitResetOption(text, 22, "soft") : resetFailedErrorMessage()
                 } else if (text.startsWith("git reset")) {
                   gitReset()
                 } else if (text.startsWith("git rm")) {

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -990,11 +990,11 @@ const InputCommand: React.FC = () => {
               }])
               if (gitInit === "Initialized empty Git repository") {
                 if (text.startsWith("git add .") || text.startsWith("git add -A")){
-                  checkDatacount(indexFiles) + checkGitAddACount < 8 ? gitAddA() : limitDataErrorMessage("indexFiles", 8)
+                  checkDatacount(indexFiles) + checkGitAddACount <= 8 ? gitAddA() : limitDataErrorMessage("indexFiles", 8)
                 } else if (text === `git remote add https://git-used-to.com/${currentUser?.userName}`){
                   gitRemoteAdd()
                 } else if (text.startsWith("git add ")){
-                  checkMultiData(text, 8, indexFiles) < 8 ? gitAdd(text, 8) : limitDataErrorMessage("indexFiles", 8)
+                  checkMultiData(text, 8, indexFiles) <= 8 ? gitAdd(text, 8) : limitDataErrorMessage("indexFiles", 8)
                 } else if (text.startsWith("kakunin")){
                   forCheck(text, 8)
                 } else if (text.startsWith("kakunin2")){
@@ -1002,14 +1002,14 @@ const InputCommand: React.FC = () => {
                 } else if (text.startsWith("git commit --amend")){
                   gitCommitAmend(text, 19)
                 } else if (text.startsWith("git commit -m")){
-                  checkDatacount(repositoryFiles) < 8
-                    && checkDatacount(commitMessages) < 10
+                  checkDatacount(repositoryFiles) <= 8
+                    && checkDatacount(commitMessages) <= 10
                   ? gitCommitM(text, 14)
                   : limitDataErrorMessage("repositoryFiles", 8)
                 } else if (text === `git push origin ${currentBranch.currentBranchName}`) {
-                  checkDatacount(remoteBranches, "remoteBranchName") < 3
-                    && checkDatacount(remoteCommitMessages, "parentRemoteBranch") < 10
-                    && checkDatacount(remoteRepositoryFiles, "parentRemoteBranch") < 16
+                  checkDatacount(remoteBranches, "remoteBranchName") <= 3
+                    && checkDatacount(remoteCommitMessages, "parentRemoteBranch") <= 10
+                    && checkDatacount(remoteRepositoryFiles, "parentRemoteBranch") <= 16
                   ? gitPush()
                   : limitDataErrorMessage("repositoryFiles", 16)
                 } else if (text.startsWith("git push --delete origin")) {
@@ -1023,21 +1023,21 @@ const InputCommand: React.FC = () => {
                 } else if (text.startsWith("git branch -d")) {
                   gitBranchD(text, 14)
                 } else if (text.startsWith("git branch ") && afterCommandBranchName.test(text.substring(11))){
-                  checkBranchCount < 3 ? gitBranch(text, 11) : limitDataErrorMessage("branch", 3)
+                  checkBranchCount <= 3 ? gitBranch(text, 11) : limitDataErrorMessage("branch", 3)
                 } else if (text.startsWith("git checkout -b ")) {
-                  checkBranchCount < 3 ? gitCheckoutB(text, 16) : limitDataErrorMessage("branch", 3)
+                  checkBranchCount <= 3 ? gitCheckoutB(text, 16) : limitDataErrorMessage("branch", 3)
                 } else if (text.startsWith("git checkout ")) {
                   gitCheckout(text, 13)
                 } else if (text.startsWith("touch ")) {
-                  checkMultiData(text, 6, worktreeFiles) < 8 ? touch(text, 6) : limitDataErrorMessage("worktreeFiles", 8)
+                  checkMultiData(text, 6, worktreeFiles) <= 8 ? touch(text, 6) : limitDataErrorMessage("worktreeFiles", 8)
                 } else if (text.startsWith("git rm --cashed")) {
                   gitRmCashed(text, 16)
                 } else if (text.startsWith("git reset --mixed HEAD~")) {
-                  Number(text.substring(23)) < 4 ? gitResetOption(text, 23, "mixed") : resetFailedErrorMessage()
+                  Number(text.substring(23)) <= 4 ? gitResetOption(text, 23, "mixed") : resetFailedErrorMessage()
                 } else if (text.startsWith("git reset --hard HEAD~")) {
-                  Number(text.substring(22)) < 4 ? gitResetOption(text, 22, "hard") : resetFailedErrorMessage()
+                  Number(text.substring(22)) <= 4 ? gitResetOption(text, 22, "hard") : resetFailedErrorMessage()
                 } else if (text.startsWith("git reset --soft HEAD~")) {
-                  Number(text.substring(22)) < 4 ? gitResetOption(text, 22, "soft") : resetFailedErrorMessage()
+                  Number(text.substring(22)) <= 4 ? gitResetOption(text, 22, "soft") : resetFailedErrorMessage()
                 } else if (text.startsWith("git reset")) {
                   gitReset()
                 } else if (text.startsWith("git rm")) {

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -151,6 +151,7 @@ const InputCommand: React.FC = () => {
 
   const gitCommitM = (text :string, str :number) => {
     const commonConditions = indexFiles.some(indexFile => indexFile.fileName !== "" && /[\S+]/.test(text.substring(str-1))) && !currentBranchParentCommitMessages.some(commitMessages => commitMessages.message === text.substring(str))
+    const removeRepositoryFiles :any = []
 
     if ((commonConditions && !currentBranchParentIndexFiles.every(indexFile => currentBranchParentRepositoryFiles.some(repositoryFile => indexFile.fileName === repositoryFile.fileName && indexFile.textStatus === repositoryFile.textStatus)))
         || (commonConditions && !currentBranchParentRepositoryFiles.every(repositoryFile => currentBranchParentIndexFiles.some(indexFile => indexFile.fileName === repositoryFile.fileName && indexFile.textStatus === repositoryFile.textStatus)))
@@ -166,35 +167,37 @@ const InputCommand: React.FC = () => {
       .filter(repositoryFile => repositoryFile.fileName)
       .forEach(filtedrepositoryFile =>
         {if (!currentBranchParentIndexFiles.some(indexFile => indexFile.fileName === filtedrepositoryFile.fileName)) {
-          setRepositoryFiles(repositoryFiles.map(repositoryFile =>
-            repositoryFile.fileName === filtedrepositoryFile.fileName
-            && repositoryFile.parentBranch === currentBranch.currentBranchName
-            ? {
-              fileName: "",
-              textStatus: "",
-              parentBranch: "",
-              parentCommitMessage: "",
-              parentBranchId: "",
-              parentCommitMessageId: "",
-              repositoryFileId: ""
-              }
-            : repositoryFile
-            )
-          )
-          setFileHistoryForCansellCommits (fileHistoryForCansellCommit => [...fileHistoryForCansellCommit,{
-            fileName :filtedrepositoryFile.fileName,
-            textStatus: "",
-            fileStatus: "deleted",
-            pastTextStatus: filtedrepositoryFile.textStatus,
-            parentBranch: currentBranch.currentBranchName,
-            parentCommitMessage: text.substring(str),
-            parentPastCommitMessage: filtedrepositoryFile.parentCommitMessage,
-            parentBranchId: currentBranch.currentBranchId,
-            parentCommitMessageId: "",
-            historyFileId: ""
-          }])
-        }}
+          removeRepositoryFiles.push(filtedrepositoryFile)
+          }}
+        )
+      setRepositoryFiles(repositoryFiles.map(repositoryFile =>
+        removeRepositoryFiles.some((removeRepositoryFile :any) => removeRepositoryFile.fileName === repositoryFile.fileName)
+        && repositoryFile.parentBranch === currentBranch.currentBranchName
+        ? {
+          fileName: "",
+          textStatus: "",
+          parentBranch: "",
+          parentCommitMessage: "",
+          parentBranchId: "",
+          parentCommitMessageId: "",
+          repositoryFileId: ""
+          }
+        : repositoryFile
+        )
       )
+      removeRepositoryFiles.forEach((removeRepositoryFile :any) =>
+      setFileHistoryForCansellCommits (fileHistoryForCansellCommit => [...fileHistoryForCansellCommit,{
+        fileName :removeRepositoryFile.fileName,
+        textStatus: "",
+        fileStatus: "deleted",
+        pastTextStatus: removeRepositoryFile.textStatus,
+        parentBranch: currentBranch.currentBranchName,
+        parentCommitMessage: text.substring(str),
+        parentPastCommitMessage: removeRepositoryFile.parentCommitMessage,
+        parentBranchId: currentBranch.currentBranchId,
+        parentCommitMessageId: "",
+        historyFileId: ""
+      }]))
       currentBranchParentIndexFiles
       .filter((indexFile) => indexFile.fileName !== "")
       .forEach((indexFile) =>

--- a/frontend/app/src/components/pages/InputCommand.tsx
+++ b/frontend/app/src/components/pages/InputCommand.tsx
@@ -1041,9 +1041,9 @@ const InputCommand: React.FC = () => {
                 } else if (text.startsWith("git branch -d")) {
                   gitBranchD(text, 14)
                 } else if (text.startsWith("git branch ") && afterCommandBranchName.test(text.substring(11))){
-                  checkBranchCount <= 3 ? gitBranch(text, 11) : limitDataErrorMessage("branch", 3)
+                  checkBranchCount < 3 ? gitBranch(text, 11) : limitDataErrorMessage("branch", 3)
                 } else if (text.startsWith("git checkout -b ")) {
-                  checkBranchCount <= 3 ? gitCheckoutB(text, 16) : limitDataErrorMessage("branch", 3)
+                  checkBranchCount < 3 ? gitCheckoutB(text, 16) : limitDataErrorMessage("branch", 3)
                 } else if (text.startsWith("git checkout ")) {
                   gitCheckout(text, 13)
                 } else if (text.startsWith("touch ")) {


### PR DESCRIPTION
概要
--
close #28 

行ったこと
--
■frontend
【クイズ作成時に制限している数以上の値を配列に格納しようとした場合にエラーを返し配列への格納が失敗する記述】
クイズの画面で各コマンド用メソッドの処理が走る前にデータ数を計算し、データ制限数が超える場合は値を新たに格納できないように制御する下記メソッドを作成。

~~~
※branch数の計算用メソッド
const checkBranchCount = branches.filter(branch => branch.branchName).length

※git add Aコマンド用
const checkGitAddACount = currentBranchParentWorktreeFiles.filter(worktreeFile => !currentBranchParentIndexFiles.some(indexFile => indexFile.fileName === worktreeFile.fileName)).length

※branch/remoteBranch以降のデータ数計算用メソッド
const checkDatacount = (datas: any, prop: string = "parentBranch") => datas.filter((data :any) => data?.[prop] === currentBranch.currentBranchName).length

※touch/git addで複数の値を指定する際に計算を行うためのメソッド  
const checkMultiData = (text :string, str :number,datas: any, prop: string = "parentBranch") => afterCommandMultipleStrings(text, str)?.length + checkDatacount(datas, prop)
~~~

【クイズデータ更新時にデータ数制限のバリデーションが誤って動作しないようにデータの追加作成/更新/削除の順番を変更】
CreateQuizButton.tsxファイル内のhandleUpdateQuizDataメソッド内で、
不要になったデータを削除する前に、新しくデータを作成する処理が走ってしまっていたため、削除の処理が先に実行されるようにメソッド内の記述の順番を変更。
~~~
具体的な例:
■worktreeFileのデータがデータ制限数の限界値(8個)の場合

クイズ編集時に格納されたworktreeFile配列内のデータを一つ削除した後に一つデータを作成した場合にもし先に削除したデータをDBに反映させずにデータを新規作成の処理が走ると、
データ数が9個になってしまいバリデーションが働いてしまう。
これは本来期待している挙動ではないため、先にデータ削除を行いバリデーションが発生しないようにしている。
~~~

■backend
【各modelファイルに保存できる数を制限する設定を記述&テスト追加】
各モデルに指定した数までしかデータを作成できないようにバリデーションを追加。
~~~
■データ制限数
branch 3個
remote_branch 3個

↓下記以降はbranch/remote_branch一つにつき作成できる数
worktree_file 8個
index_file 8個
commit_message 10個
repository_file 8個
remote_commit_message 10個
remote_repository_file 16個

↓branch一つにつき、関連するcommit_messageの種類が合計で3種類まで
quiz_history_of_committed_file 個数制限なし
~~~

行わなかったこと・その理由
--
【レイアウト/デザイン】
別ブランチでレイアウトデザインは整える予定のため、このブランチでは整えていない。
