### PR TITLE
userランキング機能の実装

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -87,6 +87,27 @@ class Api::V1::UsersController < ApplicationController
     }
   end
 
+  def user_ranking
+    rank_in_users_hash = []
+    rank_in_users = User.preload(:quizzes)
+    rank_in_users.each do |user|
+      bookmark_count = QuizBookmark.where(quiz_id: Quiz.where(user_id: user.id)).length
+      if bookmark_count >= 10
+        rank_in_users_hash.push({
+          create_user_id: user.id,
+          create_user_name: user.user_name,
+          create_user_image: user.image.url,
+          bookmark_count: bookmark_count,
+        })
+      end
+    end
+    rank_in_users_hash.sort! { |a, b| b[:bookmark_count] <=> a[:bookmark_count] }
+    render json: {
+      status: 'SUCCESS',
+      user_ranking: rank_in_users_hash,
+    }
+  end
+
   private
 
   def set_user

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
           get :profile
           get :self_bookmarked
         end
+        collection do
+          get :user_ranking
+        end
       end
       resources :quizzes, only: %i[index create update show destroy] do
         member do

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -17,6 +17,7 @@ import QuizList from "components/pages/QuizList"
 import QuizSetUp from "components/pages/QuizSetUp"
 import UserProfile from "components/pages/UserProfile"
 import QuizWeeklyRanking from "components/pages/QuizWeeklyRanking"
+import UserRanking from "components/pages/UserRanking"
 
 export const AuthContext = createContext({} as {
   loading: boolean
@@ -84,6 +85,7 @@ const App: React.FC = () => {
                 <Route exact path="/user/delete" component={UserDelete} />
                 <Route exact path="/user/quiz/list" component={QuizList} />
                 <Route exact path="/user/bookmark/list" component={QuizList} />
+                <Route exact path="/user/ranking" component={UserRanking} />
                 <Route exact path="/quiz/list" component={QuizList} />
                 <Route exact path="/quiz" component={CreateQuiz} />
                 <Route exact path="/quiz/ranking/weekly" component={QuizWeeklyRanking} />

--- a/frontend/app/src/components/pages/UserRanking.tsx
+++ b/frontend/app/src/components/pages/UserRanking.tsx
@@ -1,0 +1,40 @@
+import { getUserRanking } from "lib/api/users"
+import { useEffect, useState } from "react"
+
+const UserRanking :React.FC = () => {
+  const [rankingUsers, setRankingUSers] = useState([{
+    userId: 0,
+    userName: "",
+    userImage: "",
+    bookmarkCount: 0
+  }])
+
+  const handleGetUserRankingData = async() => {
+    const weeklyRankingQuizzesRes = await getUserRanking()
+    weeklyRankingQuizzesRes?.data.userRanking.forEach((user :any) =>
+      setRankingUSers(users => [...users,{
+        userId: user.userId,
+        userName: user.createUserName,
+        userImage: user.createUserImage,
+        bookmarkCount: user.bookmarkCount
+      }]))
+  }
+
+  useEffect(() => {
+    handleGetUserRankingData()
+  },[])
+
+  useEffect(() => {
+    console.log("rankingUsers", rankingUsers)
+  },[rankingUsers])
+
+  return(
+    <>
+      {rankingUsers.map((user, index) =>
+        <p key={index}>{user.userName}</p>
+        )}
+    </>
+  )
+}
+
+export default UserRanking

--- a/frontend/app/src/lib/api/users.ts
+++ b/frontend/app/src/lib/api/users.ts
@@ -23,6 +23,10 @@ export const getUserSelfBookmarked = (id: number | undefined | null) => {
   return client.get(`/users/${id}/self_bookmarked`)
 }
 
+export const getUserRanking = () => {
+  return client.get(`users/user_ranking`)
+}
+
 export const changeCurrentUserPassword = (data: ChangeUserPasswordFormData) => {
   return client.put("auth", data, { headers: {
     "access-token": Cookies.get("_access_token") || "",


### PR DESCRIPTION
概要
--
close #37 

行ったこと
--
■backend
【userが作成したクイズに関連しているブックマーク総数を取得するアクションを作成】
下記のアクションをusers_controllerに追加。

ブックマーク総数が10以上でないとそもそもデータが取得できず、frontendへデータを送る前にブックマーク数が多い順にデータを並び替える処理が走る。

~~~
  def user_ranking
    rank_in_users_hash = []
    rank_in_users = User.preload(:quizzes)
    rank_in_users.each do |user|
      bookmark_count = QuizBookmark.where(quiz_id: Quiz.where(user_id: user.id)).length
      if bookmark_count >= 10
        rank_in_users_hash.push({
          create_user_id: user.id,
          create_user_name: user.user_name,
          create_user_image: user.image.url,
          bookmark_count: bookmark_count,
        })
      end
    end
    rank_in_users_hash.sort! { |a, b| b[:bookmark_count] <=> a[:bookmark_count] }
    render json: {
      status: 'SUCCESS',
      user_ranking: rank_in_users_hash,
    }
  end
~~~

■frontend
【画面コンポーネント作成しデータを取得する記述を追加】
取得する値の種類と使用するapi関数が違うだけでQuizWeeklyRanking.tsxとほぼ同じ記述で作成している。

行っていないこと・その理由
--
【レイアウト/デザイン】
別ブランチでレイアウトデザインは整える予定のため、このブランチでは必要なデータをフロント側で取得できるところまでを実装している。