### PR TITLE
ゲストログイン機能の実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Auth::SessionsController < ApplicationController
+class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
   def index
     if current_api_v1_user
       render json: {
@@ -11,5 +11,16 @@ class Api::V1::Auth::SessionsController < ApplicationController
         message: "ユーザーが存在しません",
       }
     end
+  end
+
+  def guest_sign_in
+    @resource = User.guest
+    @resource.user_name = "guestusergitusedto"
+    @resource.user_self_introduction = "これは自己紹介用のフォームです。ぜひアカウントを作成してご自身の自己紹介をしてみてください！"
+    @resource.email = "guest_user@git-used-to.com"
+    @resource.password = "guestusergitusedto"
+    @token = @resource.create_token
+    @resource.save!
+    render_create_success
   end
 end

--- a/backend/app/models/quiz.rb
+++ b/backend/app/models/quiz.rb
@@ -1,4 +1,6 @@
 class Quiz < ApplicationRecord
+  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
+
   belongs_to :user
   has_many :quiz_first_or_lasts, dependent: :destroy
   has_many :quiz_answer_records, dependent: :destroy
@@ -8,4 +10,14 @@ class Quiz < ApplicationRecord
 
   validates :quiz_title, presence: true
   validates :quiz_introduction, presence: true, length: { in: 30..200 }
+
+  validate :guest_user_create_quiuz_limit, on: :create
+
+  private
+
+  def guest_user_create_quiuz_limit
+    if User.find(user_id).email === GUEST_USER_ADRESS
+      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz")
+    end
+  end
 end

--- a/backend/app/models/quiz.rb
+++ b/backend/app/models/quiz.rb
@@ -1,6 +1,4 @@
 class Quiz < ApplicationRecord
-  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
-
   belongs_to :user
   has_many :quiz_first_or_lasts, dependent: :destroy
   has_many :quiz_answer_records, dependent: :destroy
@@ -16,8 +14,8 @@ class Quiz < ApplicationRecord
   private
 
   def guest_user_create_quiuz_limit
-    if User.find(user_id).email === GUEST_USER_ADRESS
-      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz")
+    if User.find(user_id).email === "guest_user@git-used-to.com"
+      errors.add(:base, "guest_user@git-used-to.com can't create quiz")
     end
   end
 end

--- a/backend/app/models/quiz_answer_record.rb
+++ b/backend/app/models/quiz_answer_record.rb
@@ -1,6 +1,18 @@
 class QuizAnswerRecord < ApplicationRecord
+  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
+
   belongs_to :user
   belongs_to :quiz
 
   validates_uniqueness_of :quiz_id, scope: :user_id
+
+  validate :guest_user_create_quiuz_limit, on: :create
+
+  private
+
+  def guest_user_create_quiuz_limit
+    if User.find(user_id).email === GUEST_USER_ADRESS
+      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz answer records")
+    end
+  end
 end

--- a/backend/app/models/quiz_answer_record.rb
+++ b/backend/app/models/quiz_answer_record.rb
@@ -1,6 +1,4 @@
 class QuizAnswerRecord < ApplicationRecord
-  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
-
   belongs_to :user
   belongs_to :quiz
 
@@ -11,8 +9,8 @@ class QuizAnswerRecord < ApplicationRecord
   private
 
   def guest_user_create_quiuz_limit
-    if User.find(user_id).email === GUEST_USER_ADRESS
-      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz answer records")
+    if User.find(user_id).email === "guest_user@git-used-to.com"
+      errors.add(:base, "guest_user@git-used-to.com can't create quiz answer records")
     end
   end
 end

--- a/backend/app/models/quiz_bookmark.rb
+++ b/backend/app/models/quiz_bookmark.rb
@@ -1,6 +1,18 @@
 class QuizBookmark < ApplicationRecord
+  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
+
   belongs_to :quiz
   belongs_to :user
 
   validates_uniqueness_of :quiz_id, scope: :user_id
+
+  validate :guest_user_create_quiz_bookmark_limit, on: :create
+
+  private
+
+  def guest_user_create_quiz_bookmark_limit
+    if User.find(user_id).email === GUEST_USER_ADRESS
+      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz")
+    end
+  end
 end

--- a/backend/app/models/quiz_bookmark.rb
+++ b/backend/app/models/quiz_bookmark.rb
@@ -1,6 +1,4 @@
 class QuizBookmark < ApplicationRecord
-  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
-
   belongs_to :quiz
   belongs_to :user
 
@@ -11,8 +9,8 @@ class QuizBookmark < ApplicationRecord
   private
 
   def guest_user_create_quiz_bookmark_limit
-    if User.find(user_id).email === GUEST_USER_ADRESS
-      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz")
+    if User.find(user_id).email === "guest_user@git-used-to.com"
+      errors.add(:base, "guest_user@git-used-to.com can't create quiz")
     end
   end
 end

--- a/backend/app/models/quiz_comment.rb
+++ b/backend/app/models/quiz_comment.rb
@@ -1,6 +1,18 @@
 class QuizComment < ApplicationRecord
+  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
+
   belongs_to :quiz
   belongs_to :user
 
   validates :comment, presence: true, length: { in: 1..100 }
+
+  validate :guest_user_create_quiz_bookmark_limit, on: :create
+
+  private
+
+  def guest_user_create_quiz_bookmark_limit
+    if User.find(user_id).email === GUEST_USER_ADRESS
+      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz comments")
+    end
+  end
 end

--- a/backend/app/models/quiz_comment.rb
+++ b/backend/app/models/quiz_comment.rb
@@ -1,6 +1,4 @@
 class QuizComment < ApplicationRecord
-  GUEST_USER_ADRESS = "guest_user@git-used-to.com"
-
   belongs_to :quiz
   belongs_to :user
 
@@ -11,8 +9,8 @@ class QuizComment < ApplicationRecord
   private
 
   def guest_user_create_quiz_bookmark_limit
-    if User.find(user_id).email === GUEST_USER_ADRESS
-      errors.add(:base, "#{GUEST_USER_ADRESS} can't create quiz comments")
+    if User.find(user_id).email === "guest_user@git-used-to.com"
+      errors.add(:base, "guest_user@git-used-to.com can't create quiz comments")
     end
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -12,4 +12,11 @@ class User < ActiveRecord::Base
   has_many :quiz_answer_records, dependent: :destroy
   has_many :quiz_bookmarks, dependent: :destroy
   has_many :quiz_comments, dependent: :destroy
+
+  def self.guest
+    find_or_create_by!(email: "guest_user@git-used-to.com") do |user|
+      user.password = "guestusergitusedto"
+      user.user_name = "guest user"
+    end
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,8 +5,11 @@ Rails.application.routes.draw do
         registrations: 'api/v1/auth/registrations'
       }
 
-      namespace :auth do
-        resources :sessions, only: %i[index]
+      devise_scope :api_v1_user do
+        namespace :auth do
+          resources :sessions, only: %i[index]
+          post "guest_sign_in", to: "sessions#guest_sign_in"
+        end
       end
 
       resources :users, only: %i[index show update] do

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.create!(
+  user_name: 'guest user',
+  user_self_introduction: "これは自己紹介用のフォームです。ぜひアカウントを作成してご自身の自己紹介をしてみてください！",
+  email: ENV['GEST_USER_ADRESS'],
+  confirmed_at: Date.today,
+  password: ENV['GEST_USER_PASSWORD']
+)

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -5,11 +5,3 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-
-User.create!(
-  user_name: 'guest user',
-  user_self_introduction: "これは自己紹介用のフォームです。ぜひアカウントを作成してご自身の自己紹介をしてみてください！",
-  email: ENV['GEST_USER_ADRESS'],
-  confirmed_at: Date.today,
-  password: ENV['GEST_USER_PASSWORD']
-)

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe User, type: :model do
       it "userに紐づいているquizのデータも削除されること" do
         expect do
           user.destroy
-        end.to change(Quiz, :count).by(-1).and change(QuizAnswerRecord, :count).by(-1)
+        end.to change(Quiz, :count).by(-1)
       end
 
       it "userに紐づいているquiz_answer_recordのデータも削除されること" do

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -60,4 +60,24 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "self.guest" do
+    context "Userテーブルにゲストユーザーのデータが存在しない場合" do
+      it "ゲストユーザーのデータが作成されること" do
+        expect do
+          User.guest
+        end.to change(User, :count).by(+1)
+      end
+    end
+
+    context "Userテーブルにゲストユーザーのデータが存在する場合" do
+      let!(:guest_user) { create(:user, email: "guest_user@git-used-to.com") }
+
+      it "ゲストユーザーのデータが作成されないこと" do
+        expect do
+          User.guest
+        end.to change(User, :count).by(0)
+      end
+    end
+  end
 end

--- a/frontend/app/src/components/layouts/CommonLayout.tsx
+++ b/frontend/app/src/components/layouts/CommonLayout.tsx
@@ -29,7 +29,7 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
       </header>
       <main className={classes.main}>
         <Container maxWidth="lg" className={classes.container} >
-          <Grid container justify="center">
+          <Grid container justifyContent="center">
             <Grid item>
               {children}
             </Grid>

--- a/frontend/app/src/components/pages/CreateQuiz.tsx
+++ b/frontend/app/src/components/pages/CreateQuiz.tsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext, useEffect } from "react";
+import React, { useState, createContext, useEffect, useContext } from "react";
 import { useLocation, useParams } from "react-router-dom";
 
 import AboutQuiz from "./AboutQuiz";
@@ -13,6 +13,8 @@ import { getQuizCommitMessage } from "lib/api/quiz_commit_messages";
 import { getQuizRemoteBranch } from "lib/api/quiz_remote_branches";
 import { getQuizRemoteCommitMessage } from "lib/api/quiz_remote_commit_messages";
 import CreateOrUpdateQuizButton from "./CreateQuizButton";
+import { AuthContext } from "App";
+import ReccomendSignUpModal from "./RecommendSignUpModal";
 
 export const QuizContext = createContext({} as {
   quizTitle: string
@@ -410,6 +412,7 @@ export const QuizContext = createContext({} as {
 const CreateQuiz: React.FC = () => {
   const location = useLocation()
   const { id } = useParams<{ id: string }>()
+  const { currentUser } = useContext(AuthContext)
 
   const [quizTitle, setQuizTitle] = useState<string>("")
   const [quizIntroduction, setQuizIntroduction] = useState<string>("")
@@ -1008,7 +1011,10 @@ const CreateQuiz: React.FC = () => {
       <AboutQuiz />
       <Terminal />
     {/* </layout> */}
-      <CreateOrUpdateQuizButton />
+      {currentUser?.email === "guest_user@git-used-to.com"
+      ? <ReccomendSignUpModal />
+      : <CreateOrUpdateQuizButton />
+        }
         <>
         {/* ↓配列の中身確認用 */}
         <p>[branch]</p>

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -293,7 +293,7 @@ const QuizList: React.FC = () => {
       .map((quiz, index) => (
         <div key={index}>
           {currentPath(`/quiz/list`) &&
-            <p>
+            <>
               <Avatar src={quiz.parentUserImage.url} />
               <Button
                 type="submit"
@@ -307,7 +307,7 @@ const QuizList: React.FC = () => {
               >
                 {quiz.parentUserName}
               </Button>
-            </p>
+              </>
           }
           <p>{ quiz.id }</p>
           <p>{ quiz.quizTitle }</p>

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -10,6 +10,7 @@ import { Link, useLocation, useParams } from "react-router-dom";
 import QuizBookmarkButton from "./QuizBookmarkButton";
 import QuizComment from "./QuizComment";
 import QuizSearchForm from "./QuizSearchForm";
+import ReccomendSignUpModal from "./RecommendSignUpModal";
 
 export const QuizBookmarkContext = createContext({} as {
   quizzes:{
@@ -348,10 +349,13 @@ const QuizList: React.FC = () => {
           >
             解答する
           </Button>
-          <QuizBookmarkButton
-            quizId={Number(quiz.id)}
-            bookmarkId={getBookmarkId(quiz.id)}
-          />
+          {currentUser?.email === "guest_user@git-used-to.com"
+          ? <ReccomendSignUpModal />
+          : <QuizBookmarkButton
+              quizId={Number(quiz.id)}
+              bookmarkId={getBookmarkId(quiz.id)}
+            />
+            }
           <QuizComment
             quizId={Number(quiz.id)}
           />

--- a/frontend/app/src/components/pages/RecommendSignUpModal.tsx
+++ b/frontend/app/src/components/pages/RecommendSignUpModal.tsx
@@ -1,0 +1,117 @@
+import { Button, makeStyles, Modal } from "@material-ui/core"
+import { AuthContext } from "App";
+import Cookies from "js-cookie";
+import { signOut } from "lib/api/auth";
+import { useContext, useState } from "react";
+import { useHistory } from "react-router-dom";
+
+const rand = () => {
+  return Math.round(Math.random() * 20) - 10;
+}
+
+const getModalStyle = () => {
+  const top = 50 + rand();
+  const left = 50 + rand();
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`,
+  };
+}
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    position: 'absolute',
+    width: 400,
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+  },
+  submitBtn: {
+    marginTop: theme.spacing(2),
+    flexGrow: 1,
+    textTransform: "none"
+  }
+}));
+
+const ReccomendSignUpModal :React.FC = () => {
+  const classes = useStyles()
+  const history = useHistory()
+  const { setIsSignedIn } = useContext(AuthContext)
+  const [modalStyle] = useState(getModalStyle);
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleSignOut = async () => {
+    try {
+      const res = await signOut()
+
+      if (res.data.success === true) {
+        Cookies.remove("_access_token")
+        Cookies.remove("_client")
+        Cookies.remove("_uid")
+
+        setIsSignedIn(false)
+        history.push("/signup")
+
+        console.log("Succeeded in sign out")
+      } else {
+        console.log("Failed in sign out")
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  return(
+    <>
+      <Button
+        onClick={handleOpen}
+        className={classes.submitBtn}
+        type="submit"
+        variant="contained"
+        size="large"
+        fullWidth
+        color="default"
+        >
+        ゲストログイン中はここまで
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="simple-modal-title"
+        aria-describedby="simple-modal-description"
+      >
+        <div style={modalStyle} className={classes.paper}>
+          <h2 id="simple-modal-title">遊んでくれてありがとう！</h2>
+          <p id="simple-modal-description">
+            ゲストログイン中はこの先の機能を使用できません。
+            是非アカウントを作成の上、お楽しみください！
+          </p>
+          <Button
+            onClick={handleSignOut}
+            className={classes.submitBtn}
+            type="submit"
+            variant="contained"
+            size="large"
+            fullWidth
+            color="default"
+          >
+            アカウント作成へ進む
+          </Button>
+        </div>
+      </Modal>
+    </>
+  )
+}
+
+export default ReccomendSignUpModal

--- a/frontend/app/src/components/pages/RecommendSignUpModal.tsx
+++ b/frontend/app/src/components/pages/RecommendSignUpModal.tsx
@@ -3,7 +3,8 @@ import { AuthContext } from "App";
 import Cookies from "js-cookie";
 import { signOut } from "lib/api/auth";
 import { useContext, useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
+import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
 
 const rand = () => {
   return Math.round(Math.random() * 20) - 10;
@@ -38,8 +39,9 @@ const useStyles = makeStyles((theme) => ({
 
 const ReccomendSignUpModal :React.FC = () => {
   const classes = useStyles()
+  const location = useLocation()
   const history = useHistory()
-  const { setIsSignedIn } = useContext(AuthContext)
+  const { setIsSignedIn, currentUser } = useContext(AuthContext)
   const [modalStyle] = useState(getModalStyle);
   const [open, setOpen] = useState(false);
 
@@ -74,17 +76,54 @@ const ReccomendSignUpModal :React.FC = () => {
 
   return(
     <>
-      <Button
-        onClick={handleOpen}
-        className={classes.submitBtn}
-        type="submit"
-        variant="contained"
-        size="large"
-        fullWidth
-        color="default"
-        >
-        ゲストログイン中はここまで
-      </Button>
+      {location.pathname === "/quiz/list" &&
+        <Button
+          type="submit"
+          variant="contained"
+          color="default"
+          className={classes.submitBtn}
+          onClick={handleOpen}
+          >
+          <BookmarkBorderIcon />
+        </Button>
+      }
+      {location.pathname === "/quiz" &&
+        <Button
+          onClick={handleOpen}
+          className={classes.submitBtn}
+          type="submit"
+          variant="contained"
+          size="large"
+          fullWidth
+          color="default"
+          >
+          ゲストログイン中はここまで
+        </Button>
+      }
+      {location.pathname === "/quiz" &&
+        <Button
+          onClick={handleOpen}
+          className={classes.submitBtn}
+          type="submit"
+          variant="contained"
+          size="large"
+          fullWidth
+          color="default"
+          >
+          ゲストログイン中はここまで
+        </Button>
+      }
+      {location.pathname === `/user/${currentUser?.id}/edit` &&
+        <Button
+          variant="contained"
+          size="large"
+          color="default"
+          className={classes.submitBtn}
+          onClick={handleOpen}
+          >
+          Submit
+        </Button>
+      }
       <Modal
         open={open}
         onClose={handleClose}

--- a/frontend/app/src/components/pages/SignIn.tsx
+++ b/frontend/app/src/components/pages/SignIn.tsx
@@ -13,7 +13,7 @@ import Box from "@material-ui/core/Box"
 
 import { AuthContext } from "App"
 import AlertMessage from "components/utils/AlertMessage"
-import { signIn } from "lib/api/auth"
+import { guestSignIn, signIn } from "lib/api/auth"
 import { SignInParams } from "interfaces/index"
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -82,6 +82,33 @@ const SignIn: React.FC = () => {
     }
   }
 
+  const handleGuestSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+
+    try {
+      const res = await guestSignIn()
+      console.log(res)
+
+      if (res.status === 200) {
+        Cookies.set("_access_token", res.headers["access-token"])
+        Cookies.set("_client", res.headers["client"])
+        Cookies.set("_uid", res.headers["uid"])
+
+        setIsSignedIn(true)
+        setCurrentUser(res.data.data)
+
+        history.push("/")
+
+        console.log("Signed in successfully!")
+      } else {
+        setAlertMessageOpen(true)
+      }
+    } catch (err) {
+      console.log(err)
+      setAlertMessageOpen(true)
+    }
+  }
+
   return (
     <>
       <form noValidate autoComplete="off">
@@ -120,6 +147,17 @@ const SignIn: React.FC = () => {
               onClick={handleSubmit}
             >
               Submit
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              fullWidth
+              color="default"
+              className={classes.submitBtn}
+              onClick={handleGuestSubmit}
+            >
+              ゲストログインはこちら
             </Button>
             <Box textAlign="center" className={classes.box}>
               <Typography variant="body2">

--- a/frontend/app/src/components/pages/UserEdit.tsx
+++ b/frontend/app/src/components/pages/UserEdit.tsx
@@ -9,10 +9,9 @@ import CancelIcon from "@material-ui/icons/Cancel"
 import { IconButton } from "@material-ui/core";
 import PhotoCamera from "@material-ui/icons/PhotoCamera"
 import { Typography } from "@material-ui/core";
-
-
 import { AuthContext } from "App"
 import { updateUser } from "lib/api/users";
+import ReccomendSignUpModal from "./RecommendSignUpModal";
 
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -162,24 +161,29 @@ const UserEdit: React.FC = () => {
           </Box>
         ) : null
       }
-      <Button
-        onClick={handleFormSubmit}
-        disabled={!name || !introduction ? true : false}
-      >
-        送信
-      </Button>
-      <Box textAlign="center" className={classes.box}>
-        <Typography variant="body2">
-          <Link to="/password" className={classes.link}>
-            パスワード変更はこちら
-          </Link>
-        </Typography>
-        <Typography>
-          <Link to="/user/delete" className={classes.link}>
-            アカウント削除はこちら
-          </Link>
-        </Typography>
-      </Box>
+      {currentUser?.email === "guest_user@git-used-to.com"
+        ? <ReccomendSignUpModal />
+        : <>
+            <Button
+              onClick={handleFormSubmit}
+              disabled={!name || !introduction ? true : false}
+            >
+              送信
+            </Button>
+            <Box textAlign="center" className={classes.box}>
+              <Typography variant="body2">
+                <Link to="/password" className={classes.link}>
+                  パスワード変更はこちら
+                </Link>
+              </Typography>
+              <Typography>
+                <Link to="/user/delete" className={classes.link}>
+                  アカウント削除はこちら
+                </Link>
+              </Typography>
+            </Box>
+          </>
+        }
     </form>
   )
 }

--- a/frontend/app/src/lib/api/auth.ts
+++ b/frontend/app/src/lib/api/auth.ts
@@ -11,6 +11,10 @@ export const signIn = (params: SignInParams)  => {
   return client.post("auth/sign_in", params)
 }
 
+export const guestSignIn = ()  => {
+  return client.post("auth/guest_sign_in")
+}
+
 export const signOut = () => {
   return client.delete("auth/sign_out", { headers: {
     "access-token": Cookies.get("_access_token") || "",


### PR DESCRIPTION
概要
--
close #41 

行ったこと
--
■backend
【ゲストログイン用データを作成するメソッドの追加】
ゲストログイン用のデータがuserテーブル内に存在しない場合は作成し、存在する場合はそのデータを取得するメソッドをmodelに追加。
~~~
def self.guest
    find_or_create_by!(email: "guest_user@git-used-to.com") do |user|
      user.password = "guestusergitusedto"
      user.user_name = "guest user"
    end
  end
~~~

【ゲストログイン用データでログインをするアクションの追加】
self.guestメソッドで取得したuserデータを指定した値に更新した上で、
認証に必要なtokenを作成しフロントへログインに必要なデータを返す記述を追加。

~~~
値を更新している理由:
フロントで値を編集することができないように記述しているが、
悪意あるユーザーが値を変更した場合でも再度ゲストログインが行われた場合は値が本来の値に戻るようにするため。

def guest_sign_in
    @resource = User.guest
    @resource.user_name = "guestusergitusedto"
    @resource.user_self_introduction = "これは自己紹介用のフォームです。ぜひアカウントを作成してご自身の自己紹介をしてみてください！"
    @resource.email = "guest_user@git-used-to.com"
    @resource.password = "guestusergitusedto"
    @token = @resource.create_token
    @resource.save!
    render_create_success
  end
~~~

【ゲストログインのuser_idで"quiz/comment/bookmark"の作成が失敗するバリデーションの追加】
user_idがゲストログイン用のデータのidだった場合に失敗するようにバリデーションを作成。

■frontend
【ゲストログイン時に表示される画面が変更される処理を追加】
下記の記述でゲストログイン中かどうかを判別し、表示する画面を変更する記述を各ファイルに追加。

追加箇所は、クイズデータ作成ボタン/プロフィール編集ボタン/ブックマーク追加ボタン。
ボタンを押した場合はデータの作成/編集は行われずにアカウント作成を案内するモーダルが表示されるようになっている。
~~~
currentUser?.email === guest_user@git-used-to.com
~~~

行っていないこと・その理由
--
■backend
【ゲストユーザーの情報編集/削除が失敗するバリデーション】
ゲストログインデータの更新や削除を制限すると、サインイン/サインアウトが失敗してしまい挙動の制限が必要以上にかかってしまう。
サインイン時にtokenが作成され、サインアウト時にtokenが削除される際におそらくbefore destroyのバリデーションが発火してしまいアカウントを削除できなくなるがサインアウトもできなくなるという状態になっていたため、バリデーションは作成しなかった。

そもそもフロント側で値の削除や更新ができないように実装しているが、
値が万が一変更されてしまったとしてもself.guestメソッドで元の値に更新をした上でゲストログインのデータをフロントに渡すように記述している。

■frontend
【ゲストログイン中のコメント投稿ボタンの処理の変更】
クイズ作成/プロフィール編集/ブックマーク追加のボタンと同じようにコメント投稿ボタンもゲストログイン中は行えないように処理を実装すべきだが、していない。
理由はそもそもコメント機能をどこに実装するかを明確にまだ決定できていないこと。
実装場所が決まり次第、コメント機能のゲストログイン中の処理の変更も行う。

