### PR TITLE
管理者アカウントのみ他userのデータを削除できる機能を追加

### DIFF
--- a/frontend/app/src/components/pages/QuizComment.tsx
+++ b/frontend/app/src/components/pages/QuizComment.tsx
@@ -116,6 +116,8 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
     }
   }
 
+  const commentDeleteUser = (commentedUserId :number) => commentedUserId === currentUser?.id || currentUser?.email === "admin@git-used-to.com"
+
   return(
     <div >
       <Button
@@ -148,7 +150,7 @@ const QuizComment: React.FC<{ quizId: number }> = ({quizId}) => {
                 </div>
                 <div>
                   コメント:<br /> {comment.comment.comment}
-                  {comment.comment.userId === currentUser?.id &&
+                  {commentDeleteUser(comment.comment.userId) &&
                     <Button
                       onClick={e => handleDeleteQuizCommentSubmit(e, comment.comment.id)}
                       >

--- a/frontend/app/src/components/pages/QuizList.tsx
+++ b/frontend/app/src/components/pages/QuizList.tsx
@@ -122,6 +122,8 @@ const QuizList: React.FC = () => {
     )
   }
 
+  const quizDeleteUser = (quizCreatedUser :number) => quizCreatedUser === currentUser?.id || currentUser?.email === "admin@git-used-to.com"
+
 
   return(
     <>
@@ -174,7 +176,7 @@ const QuizList: React.FC = () => {
               </div>
             </div>
             <div className={classes.rightPosition}>
-              {Number(quiz.userId) === currentUser?.id && <QuizEditButton quizId={Number(quiz.id)}/>}
+              {quizDeleteUser(Number(quiz.userId)) && <QuizEditButton quizId={Number(quiz.id)}/>}
               <Button
                 type="submit"
                 variant="contained"

--- a/frontend/app/src/components/pages/SignIn.tsx
+++ b/frontend/app/src/components/pages/SignIn.tsx
@@ -135,9 +135,8 @@ const SignIn: React.FC = () => {
               </Button>
               <Box textAlign="center" className={classes.box}>
                 <Typography variant="body2">
-                  Don't have an account? &nbsp;
                   <Link to="/signup" className={classes.link}>
-                    Sign Up now!
+                    アカウント作成はこちら
                   </Link>
                 </Typography>
                 <Typography variant="body2">


### PR DESCRIPTION
概要
--
close #52 

行ったこと
--
■frontend

【クイズ一覧でクイズ削除ボタンが管理者アカウントだと全て表示されるように処理を修正】
~~~
git-used-to/frontend/app/src/components/pages/QuizList.tsx

※ログインユーザーが管理者アカウントまたは、クイズ作成者ユーザーか判別するメソッド
const quizDeleteUser = (quizCreatedUser :number) => quizCreatedUser === currentUser?.id || currentUser?.email === "admin@git-used-to.com"

※クイズごとのクイズ作成userのidを引数にして、quizDeleteUserメソッドがtrueだった場合、クイズを編集できるボタンが表示される
{quizDeleteUser(Number(quiz.userId)) && <QuizEditButton quizId={Number(quiz.id)}/>}
~~~

【管理者アカウントだった場合、コメント画面(モーダル)内のコメントの削除ボタンが表示されるように処理を追加】
~~~
git-used-to/frontend/app/src/components/pages/QuizComment.tsx

※ログインユーザーが管理者アカウントまたは、コメントをしたユーザーか判別するメソッド
const commentDeleteUser = (commentedUserId :number) => commentedUserId === currentUser?.id || currentUser?.email === "admin@git-used-to.com"

※commentDeleteUserメソッドがtrueの場合、コメント削除ボタンが表示される
{commentDeleteUser(comment.comment.userId) &&
  <Button
     onClick={e => handleDeleteQuizCommentSubmit(e, comment.comment.id)}
     >
     <DeleteIcon />
  </Button>
}
~~~

【サインイン画面からサインアップ画面に移動するリンクの文言を修正】
 "アカウント作成はこちら"のテキストが英語表記だったため、日本語に変更。
~~~
git-used-to/frontend/app/src/components/pages/SignIn.tsx

<Typography variant="body2">
  <Link to="/signup" className={classes.link}> 
     アカウント作成はこちら
  </Link>
</Typography>
~~~